### PR TITLE
Token: Add support for makeCardToken method

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (4.8.2)
-  - ProcessOut (2.8.1):
+  - ProcessOut (2.8.2):
     - Alamofire (~> 4.8.2)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  ProcessOut: ec49d300f2c7a0952beabde99439d53c84927513
+  ProcessOut: f9ebded0063cfc41522dfb4b2f38d017740ab7cf
 
 PODFILE CHECKSUM: 7a2e16c8b92e3901e46423df8a155db5ccd8c114
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (4.8.2)
-  - ProcessOut (2.8.2):
+  - ProcessOut (2.9.0):
     - Alamofire (~> 4.8.2)
 
 DEPENDENCIES:
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  ProcessOut: f9ebded0063cfc41522dfb4b2f38d017740ab7cf
+  ProcessOut: fea19a7e5fefc55db549ffda6dcb548f27956048
 
 PODFILE CHECKSUM: 7a2e16c8b92e3901e46423df8a155db5ccd8c114
 

--- a/Example/ProcessOut/AppDelegate.swift
+++ b/Example/ProcessOut/AppDelegate.swift
@@ -23,28 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     // This method handles opening native URLs (e.g., "yourapp://")
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if let processoutResult = ProcessOut.handleURLCallback(url: url) {
-            if processoutResult.success {
-                switch processoutResult.type {
-                case .APMAuthorization:
-                   let token = processoutResult.value
-                    // You can now send this token to your backend to complete the charge
-                    break
-                case .ThreeDSResult:
-                    let invoiceId = processoutResult.value
-                    // Send the invoice ID to your backend to complete the charge
-                case .ThreeDSFallbackVerification:
-                    ProcessOut.continueThreeDSVerification(invoiceId: processoutResult.invoiceId, token: processoutResult.value) { (invoiceId, error) in
-                        // Send the invoice to your backend to complete the charge
-                    }
-                }
-            } else {
-                // Authorization failed
-            }
-        } else {
-            // This was not a processout url – do whatever url handling your app
-            // normally does, if any.
-            return false
+        if let token = ProcessOut.handleURLCallback(url: url) {
+            print(token)
         }
         return false
     }

--- a/Example/ProcessOut/Info.plist
+++ b/Example/ProcessOut/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Example/ProcessOut/ViewController.swift
+++ b/Example/ProcessOut/ViewController.swift
@@ -9,8 +9,9 @@
 import UIKit
 import ProcessOut
 import PassKit
+import WebKit
 
-class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDelegate {
+class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDelegate, WKUIDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -45,55 +46,13 @@ class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDele
             } else {
                 // Use the card token to initiate an authorization/charge
                 if token != nil {
+                    //Initiate a card payment from an invoice generated on your backend
                     ProcessOut.makeCardPayment(invoiceId: "invoice-id", token: token!, handler: ProcessOut.createThreeDSTestHandler(viewController: self, completion: { (invoiceId, error) in
                         // Send the invoice to your backend to complete the charge
+                        print(invoiceId)
+                        print(error)
                     }), with: self)
                 }
-            }
-        })
-    }
-    
-    func testThreeDS2Payment(token: String) {
-        ProcessOut.makeCardPayment(invoiceId: "invoice-id", token: token, handler: ProcessOut.createThreeDSTestHandler(viewController: self, completion: { (invoiceId, error) in
-            if invoiceId != nil {
-                // Authorization successful
-            } else {
-                // Display error
-            }
-        }), with: self)
-    }
-    
-    func testTokenization() {
-        let contact = ProcessOut.Contact(address1: "1 great street", address2: nil, city: "City", state: "State", zip: "10000", countryCode: "US")
-        let card = ProcessOut.Card(cardNumber: "4242424242424242", expMonth: 11, expYear: 19, cvc: nil, name: "Jeremy Lejoux", contact: contact)
-        ProcessOut.Tokenize(card: card, metadata: [:], completion: {(token, error) -> Void in
-            if error != nil {
-                switch error! {
-                case .BadRequest(let message, let code):
-                    // developers, message can help you
-                    print(message, code)
-                    
-                case .MissingProjectId:
-                    print("Check your app delegate file")
-                case .InternalError:
-                    print("An internal error occured")
-                case .NetworkError:
-                    print("Request could not go through")
-                case .GenericError(let error):
-                    print(error)
-                }
-            } else {
-                // send token to your backend to charge the customer
-                print(token!)
-            }
-        })
-        
-        ProcessOut.UpdateCvc(cardId: "a_card_token", newCvc: "123", completion: { (error) in
-            if error != nil {
-                // an error occured
-                print(error!)
-            } else {
-                // card CVC updated
             }
         })
     }

--- a/Example/ProcessOut/ViewController.swift
+++ b/Example/ProcessOut/ViewController.swift
@@ -11,7 +11,7 @@ import ProcessOut
 import PassKit
 import WebKit
 
-class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDelegate, WKUIDelegate {
+class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -26,7 +26,7 @@ class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDele
     @IBAction func clicked(_ sender: Any) {
         // either test applepaye tokenization or card
         let contact = ProcessOut.Contact(address1: "1 great street", address2: nil, city: "City", state: "State", zip: "10000", countryCode: "US")
-        let card = ProcessOut.Card(cardNumber: "4000000000003253", expMonth: 10, expYear: 20, cvc: "737", name: "Jeremy Lejoux", contact: contact)
+        let card = ProcessOut.Card(cardNumber: "4000000000003246", expMonth: 10, expYear: 20, cvc: "737", name: "Jeremy Lejoux", contact: contact)
         ProcessOut.Tokenize(card: card, metadata: [:], completion: {(token, error) -> Void in
             if error != nil {
                 switch error! {

--- a/Example/ProcessOut/ViewController.swift
+++ b/Example/ProcessOut/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDele
     @IBAction func clicked(_ sender: Any) {
         // either test applepaye tokenization or card
         let contact = ProcessOut.Contact(address1: "1 great street", address2: nil, city: "City", state: "State", zip: "10000", countryCode: "US")
-        let card = ProcessOut.Card(cardNumber: "4000000000003246", expMonth: 10, expYear: 20, cvc: "737", name: "Jeremy Lejoux", contact: contact)
+        let card = ProcessOut.Card(cardNumber: "4000000000003253", expMonth: 10, expYear: 20, cvc: "737", name: "Jeremy Lejoux", contact: contact)
         ProcessOut.Tokenize(card: card, metadata: [:], completion: {(token, error) -> Void in
             if error != nil {
                 switch error! {

--- a/Example/ProcessOut_UITests/Info.plist
+++ b/Example/ProcessOut_UITests/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationCategoryType</key>
+	<string></string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -148,31 +148,36 @@ class ProcessOutUITests: XCTestCase {
     
     // HELPERS functions
     func createInvoice(invoice: Invoice, completion: @escaping (String?, Error?) -> Void) {
-        if let body = try? JSONEncoder().encode(invoice), let authorizationHeader = Request.authorizationHeader(user: projectId, password: projectKey) {
-            do {
-                let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
-                var headers: HTTPHeaders = [:]
-                
-                headers[authorizationHeader.key] = authorizationHeader.value
-                Alamofire.request("https://api.processout.ninja/invoices", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON(completionHandler: {(response) -> Void in
-                    switch response.result {
-                    case .success(let data):
-                        guard let j = data as? [String: AnyObject] else {
-                            completion(nil, ProcessOutException.InternalError)
-                            return
-                        }
-                        if let inv = j["invoice"] as? [String: AnyObject], let id = inv["id"] as? String {
-                            completion(id, nil)
-                        } else {
-                            completion(nil, ProcessOutException.InternalError)
-                        }
-                    default:
+        guard let body = try? JSONEncoder().encode(invoice), let authorizationHeader = Request.authorizationHeader(user: projectId, password: projectKey) else {
+            completion(nil, ProcessOutException.InternalError)
+            return
+        }
+        
+        do {
+            let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
+            var headers: HTTPHeaders = [:]
+            
+            headers[authorizationHeader.key] = authorizationHeader.value
+            Alamofire.request("https://api.processout.com/invoices", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON(completionHandler: {(response) -> Void in
+                switch response.result {
+                case .success(let data):
+                    guard let j = data as? [String: AnyObject] else {
                         completion(nil, ProcessOutException.InternalError)
+                        return
                     }
-                })
-            } catch {
-                completion(nil, error)
-            }
+                    
+                    guard let inv = j["invoice"] as? [String: AnyObject], let id = inv["id"] as? String else {
+                        completion(nil, ProcessOutException.InternalError)
+                        return
+                    }
+                    
+                    completion(id, nil)
+                default:
+                    completion(nil, ProcessOutException.InternalError)
+                }
+            })
+        } catch {
+            completion(nil, error)
         }
     }
     
@@ -187,18 +192,18 @@ class ProcessOutUITests: XCTestCase {
             let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String: Any]
             var headers: HTTPHeaders = [:]
             headers[authorizationHeader.key] = authorizationHeader.value
-            Alamofire.request("https://api.processout.ninja/customers", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON { (response) in
+            Alamofire.request("https://api.processout.com/customers", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON { (response) in
                 switch response.result {
                 case .success(let data):
                     guard let j = data as? [String: AnyObject] else {
                         completion(nil, ProcessOutException.InternalError)
                         return
                     }
-                    if let cust = j["customer"] as? [String: AnyObject], let id = cust["id"] as? String {
-                        completion(id, nil)
-                    } else {
+                    guard let cust = j["customer"] as? [String: AnyObject], let id = cust["id"] as? String else {
                         completion(nil, ProcessOutException.InternalError)
+                        return
                     }
+                    completion(id, nil)
                 default:
                     completion(nil, ProcessOutException.InternalError)
                 }
@@ -219,18 +224,18 @@ class ProcessOutUITests: XCTestCase {
             let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String: AnyObject]
             var headers: HTTPHeaders = [:]
             headers[authorizationHeader.key] = authorizationHeader.value
-            Alamofire.request("https://api.processout.ninja/customers/" + customerId + "/tokens", method: .post, parameters: json, encoding :JSONEncoding.default, headers: headers).responseJSON {(response) in
+            Alamofire.request("https://api.processout.com/customers/" + customerId + "/tokens", method: .post, parameters: json, encoding :JSONEncoding.default, headers: headers).responseJSON {(response) in
                 switch response.result {
                 case .success(let data):
                     guard let j = data as? [String: AnyObject] else {
                         completion(nil, ProcessOutException.InternalError)
                         return
                     }
-                    if let cust = j["token"] as? [String: AnyObject], let id = cust["id"] as? String {
-                        completion(id, nil)
-                    } else {
+                    guard let cust = j["token"] as? [String: AnyObject], let id = cust["id"] as? String else {
                         completion(nil, ProcessOutException.InternalError)
+                        return
                     }
+                    completion(id, nil)
                 default:
                     completion(nil, ProcessOutException.InternalError)
                 }

--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -7,14 +7,13 @@
 //
 
 import XCTest
-import Pods_ProcessOut_Example_ProcessOut_UITests
 import ProcessOut
 import Alamofire
 
 class ProcessOutUITests: XCTestCase {
 
-    var projectId = "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x"
-    var projectKey = "key_sandbox_mah31RDFqcDxmaS7MvhDbJfDJvjtsFTB"
+    var projectId = "test-proj_dHvuowrjviYWm7ZX0hXlb7X2yaxdgo06"
+    var projectKey = "key_test_kRdQo3Jm7ybpDqflvbC0T0Mc7UDN1g8t"
     
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -118,7 +117,7 @@ class ProcessOutUITests: XCTestCase {
                 }
                 
                 // Create the customer token
-                self.createCustomerToken(customerId: customerId!, cardId: token!, completion: { (customerTokenId, error) in
+                self.createCustomerToken(customerId: customerId!, cardId: "", completion: { (customerTokenId, error) in
                     
                     guard error == nil else {
                         print(error!)
@@ -126,7 +125,7 @@ class ProcessOutUITests: XCTestCase {
                         return
                     }
                     
-                    ProcessOut.makeCardToken(cardId: token!, customerId: customerId!, tokenId: customerTokenId!, handler: ProcessOut.createThreeDSTestHandler(viewController: view, completion: { (invoiceId, error) in
+                    ProcessOut.makeCardToken(source: token!, customerId: customerId!, tokenId: customerTokenId!, handler: ProcessOut.createThreeDSTestHandler(viewController: view, completion: { (invoiceId, error) in
                         
                         guard error == nil else {
                             print(error!)
@@ -134,6 +133,7 @@ class ProcessOutUITests: XCTestCase {
                             return
                         }
                         
+                        print(invoiceId)
                         XCTAssertNotNil(invoiceId)
                         
                         expectation.fulfill()
@@ -142,7 +142,7 @@ class ProcessOutUITests: XCTestCase {
             })
         })
         
-        wait(for: [expectation], timeout: 15.0)
+        wait(for: [expectation], timeout: 150.0)
     }
     
     
@@ -154,7 +154,7 @@ class ProcessOutUITests: XCTestCase {
                 var headers: HTTPHeaders = [:]
                 
                 headers[authorizationHeader.key] = authorizationHeader.value
-                Alamofire.request("https://api.processout.com/invoices", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON(completionHandler: {(response) -> Void in
+                Alamofire.request("https://api.processout.ninja/invoices", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON(completionHandler: {(response) -> Void in
                     switch response.result {
                     case .success(let data):
                         guard let j = data as? [String: AnyObject] else {
@@ -187,7 +187,7 @@ class ProcessOutUITests: XCTestCase {
             let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String: Any]
             var headers: HTTPHeaders = [:]
             headers[authorizationHeader.key] = authorizationHeader.value
-            Alamofire.request("https://api.processout.com/customers", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON { (response) in
+            Alamofire.request("https://api.processout.ninja/customers", method: .post, parameters: json, encoding: JSONEncoding.default, headers: headers).responseJSON { (response) in
                 switch response.result {
                 case .success(let data):
                     guard let j = data as? [String: AnyObject] else {
@@ -219,7 +219,7 @@ class ProcessOutUITests: XCTestCase {
             let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String: AnyObject]
             var headers: HTTPHeaders = [:]
             headers[authorizationHeader.key] = authorizationHeader.value
-            Alamofire.request("https://api.processout.com/customers/" + customerId + "/tokens", method: .post, parameters: json, encoding :JSONEncoding.default, headers: headers).responseJSON {(response) in
+            Alamofire.request("https://api.processout.ninja/customers/" + customerId + "/tokens", method: .post, parameters: json, encoding :JSONEncoding.default, headers: headers).responseJSON {(response) in
                 switch response.result {
                 case .success(let data):
                     guard let j = data as? [String: AnyObject] else {

--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -12,8 +12,8 @@ import Alamofire
 
 class ProcessOutUITests: XCTestCase {
 
-    var projectId = "test-proj_dHvuowrjviYWm7ZX0hXlb7X2yaxdgo06"
-    var projectKey = "key_test_kRdQo3Jm7ybpDqflvbC0T0Mc7UDN1g8t"
+    var projectId = "test-proj_gAO1Uu0ysZJvDuUpOGPkUBeE3pGalk3x"
+    var projectKey = "key_sandbox_mah31RDFqcDxmaS7MvhDbJfDJvjtsFTB"
     
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.

--- a/ProcessOut.podspec
+++ b/ProcessOut.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ProcessOut'
-  s.version          = '2.8.2'
+  s.version          = '2.9.0'
   s.summary          = 'The smart router for payments. Smartly route each transaction to the relevant payment providers.'
 
 # This description is used to generate tags and improve search results.

--- a/ProcessOut/Classes/AuthorizationResult.swift
+++ b/ProcessOut/Classes/AuthorizationResult.swift
@@ -5,26 +5,7 @@
 //  Created by Jeremy Lejoux on 17/06/2019.
 //
 
-class AuthorizationResult: ApiResponse {
-    public class CustomerAction: Codable {
-        
-        enum CustomerActionType: String, Codable {
-            case fingerPrintMobile = "fingerprint-mobile"
-            case challengeMobile = "challenge-mobile"
-            case url = "url"
-            case redirect = "redirect"
-            case fingerprint = "fingerprint"
-        }
-        
-        public var type: CustomerActionType = CustomerActionType.redirect
-        public var value: String = ""
-        
-        enum CodingKeys: String, CodingKey {
-            case type = "type"
-            case value = "value"
-        }
-    }
-    
+class AuthorizationResult: ApiResponse {    
     public var customerAction: CustomerAction?
     
     private enum CodingKeys: String, CodingKey {

--- a/ProcessOut/Classes/CardPaymentWebView.swift
+++ b/ProcessOut/Classes/CardPaymentWebView.swift
@@ -1,0 +1,19 @@
+//
+//  CardPaymentWebView.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 30/09/2019.
+//
+
+import Foundation
+
+class CardPaymentWebView: ProcessOutWebView {
+    
+    override func onRedirect(url: URL) {
+        guard let parameters = url.queryParameters, let token = parameters["token"] else {
+            return
+        }
+        
+        onResult(token)
+    }
+}

--- a/ProcessOut/Classes/CardTokenWebView.swift
+++ b/ProcessOut/Classes/CardTokenWebView.swift
@@ -1,0 +1,19 @@
+//
+//  CardTokenWebView.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 30/09/2019.
+//
+
+import Foundation
+
+class CardTokenWebView: ProcessOutWebView {
+    
+    override func onRedirect(url: URL) {
+        guard let parameters = url.queryParameters, let token = parameters["token"] else {
+            return
+        }
+        
+        onResult(token)
+    }
+}

--- a/ProcessOut/Classes/CustomerAction.swift
+++ b/ProcessOut/Classes/CustomerAction.swift
@@ -1,0 +1,27 @@
+//
+//  CustomerAction.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 19/09/2019.
+//
+
+import Foundation
+
+public class CustomerAction: Codable {
+    
+    public enum CustomerActionType: String, Codable {
+        case fingerPrintMobile = "fingerprint-mobile"
+        case challengeMobile = "challenge-mobile"
+        case url = "url"
+        case redirect = "redirect"
+        case fingerprint = "fingerprint"
+    }
+    
+    public var type: CustomerActionType = CustomerActionType.redirect
+    public var value: String = ""
+    
+    enum CodingKeys: String, CodingKey {
+        case type = "type"
+        case value = "value"
+    }
+}

--- a/ProcessOut/Classes/CustomerActionHandler.swift
+++ b/ProcessOut/Classes/CustomerActionHandler.swift
@@ -1,0 +1,174 @@
+//
+//  CustomerActionHandler.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 19/09/2019.
+//
+
+import Foundation
+import UIKit
+import WebKit
+
+
+class CustomerActionHandler {
+    
+    var handler: ThreeDSHandler
+    var with: UIViewController
+    
+    public init(handler: ThreeDSHandler, with: UIViewController) {
+        self.handler = handler
+        self.with = with
+    }
+    
+    
+    public func handleCustomerAction(customerAction: CustomerAction, completion: @escaping (String) -> Void) {
+        switch customerAction.type{
+        case .fingerPrintMobile:
+            performFingerprint(customerAction: customerAction, handler: handler, completion: { (encodedData, error) in
+                if encodedData != nil {
+                    completion(encodedData!)
+                } else {
+                    self.handler.onError(error: error!)
+                }
+            })
+        case .challengeMobile:
+            performChallenge(customerAction: customerAction, handler: handler) { (success, error) in
+                if (success) {
+                    completion(ProcessOut.threeDS2ChallengeSuccess)
+                } else {
+                    completion(ProcessOut.threeDS2ChallengeError)
+                }
+            }
+            
+        case .url, .redirect:
+            // need to open a new web tab
+            guard let url = URL(string: customerAction.value) else {
+                // Invalid URL
+                handler.onError(error: ProcessOutException.InternalError)
+                return
+            }
+            
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            } else {
+                UIApplication.shared.openURL(url)
+            }
+            break
+            
+        case .fingerprint:
+            // Need to open a webview for fingerprinting fallback
+            
+            guard let url = URL(string: customerAction.value) else {
+                // Invalid URL
+                handler.onError(error: ProcessOutException.InternalError)
+                return
+            }
+            // Prepare the fingerprint hiddenWebview
+            var webView: WKWebView!
+            let preferences = WKPreferences()
+            preferences.javaScriptEnabled = true
+            let configuration = WKWebViewConfiguration()
+            // Check if the device supports custom URL scheme handling for WebViews
+            if #available(iOS 11.0, *), let appURLScheme = ProcessOut.UrlScheme {
+                // Setup the fingerprint timeout handler
+                let timeOutHandler = DispatchWorkItem {
+                    // Remove the webview
+                    webView.removeFromSuperview()
+                    webView = nil
+                    // Fallback to default fingerprint values
+                    let fallback = self.generateFallbackFingerprintToken(URL: customerAction.value)
+                    guard fallback.error == nil else {
+                        self.handler.onError(error: fallback.error!)
+                        return
+                    }
+                    
+                    completion(fallback.fallbackToken!)
+                }
+                configuration.preferences = preferences
+                // Setup the custom URL scheme handler to detect redirects within the hidden webview
+                configuration.setURLSchemeHandler(FingerPrintWebViewSchemeHandler(completion: {(invoiceId, token, error) in
+                    // Cancel the timeout as we catched the redirect
+                    timeOutHandler.cancel()
+                    if error != nil {
+                        self.handler.onError(error: error!)
+                    } else {
+                        // Fingerprint token successfully received, we continue the authorization flow
+                        completion(token!)
+                    }
+                }), forURLScheme: appURLScheme)
+                // Add the webview to the app view
+                webView = WKWebView(frame: with.view.frame, configuration: configuration)
+                webView.load(URLRequest(url: url))
+                webView.isHidden = true
+                with.view.addSubview(webView)
+                
+                // Start the timeout handler with a 10s timeout
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeOutHandler)
+            } else {
+                // Fallback on earlier versions
+                let fallback = self.generateFallbackFingerprintToken(URL: customerAction.value)
+                guard fallback.error == nil else {
+                    handler.onError(error: fallback.error!)
+                    return
+                }
+                
+                completion(fallback.fallbackToken!)
+            }
+            
+            break
+        }
+    }
+    
+    private func performFingerprint(customerAction: CustomerAction, handler: ThreeDSHandler, completion: @escaping (String?, ProcessOutException?) -> Void) {
+        do {
+            let decodedData = Data(base64Encoded: customerAction.value)!
+            let directoryServerData = try JSONDecoder().decode(DirectoryServerData.self, from: decodedData)
+            handler.doFingerprint(directoryServerData: directoryServerData) { (response) in
+                do {
+                    if let body = String(data: try JSONEncoder().encode(response), encoding: .utf8) {
+                        let miscGatewayRequest = MiscGatewayRequest(fingerprintResponse: body)
+                        if let gatewayToken = miscGatewayRequest.generateToken() {
+                            completion(gatewayToken, nil)
+                        } else {
+                            completion(nil, ProcessOutException.InternalError)
+                        }
+                    } else {
+                        completion(nil, ProcessOutException.InternalError)
+                    }
+                } catch {
+                    completion(nil, ProcessOutException.InternalError)
+                }
+                
+            }
+        } catch {
+            completion(nil, ProcessOutException.InternalError)
+        }
+    }
+    
+    private func performChallenge(customerAction: CustomerAction, handler: ThreeDSHandler, completion: @escaping (Bool, ProcessOutException?) -> Void) {
+        do {
+            if let decodedB64Data = Data(base64Encoded: customerAction.value) {
+                let authentificationChallengeData = try JSONDecoder().decode(AuthentificationChallengeData.self, from: decodedB64Data)
+                handler.doChallenge(authentificationData: authentificationChallengeData) { (success) in
+                    completion(success, nil)
+                }
+            } else {
+                completion(false, ProcessOutException.InternalError)
+            }
+        } catch {
+            completion(false, ProcessOutException.InternalError)
+        }
+        
+    }
+    
+    private func generateFallbackFingerprintToken(URL: String) -> (fallbackToken: String?, error: ProcessOutException?) {
+        let miscGatewayRequest = MiscGatewayRequest(fingerprintResponse: "{\"threeDS2FingerprintTimeout\":true}")
+        miscGatewayRequest.headers = ["Content-Type": "application/json"]
+        miscGatewayRequest.url = URL
+        if let gatewayToken = miscGatewayRequest.generateToken() {
+            return (gatewayToken, nil)
+        } else {
+            return (nil, ProcessOutException.InternalError)
+        }
+    }
+}

--- a/ProcessOut/Classes/CustomerRequest.swift
+++ b/ProcessOut/Classes/CustomerRequest.swift
@@ -1,0 +1,27 @@
+//
+//  CustomerRequest.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 19/09/2019.
+//
+
+import Foundation
+
+public class CustomerRequest: Encodable {
+    
+    var firstName: String = ""
+    var lastName: String = ""
+    var currency: String = ""
+    
+    enum CodingKeys: String, CodingKey {
+        case firstName = "first_name"
+        case lastName = "last_name"
+        case currency = "currency"
+    }
+    
+    public init(firstName: String, lastName: String, currency: String) {
+        self.firstName = firstName
+        self.lastName = lastName
+        self.currency = currency
+    }
+}

--- a/ProcessOut/Classes/CustomerTokenRequest.swift
+++ b/ProcessOut/Classes/CustomerTokenRequest.swift
@@ -1,0 +1,20 @@
+//
+//  CustomerTokenRequest.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 19/09/2019.
+//
+
+import Foundation
+
+public class CustomerTokenRequest: Encodable {
+    var source: String = ""
+    
+    enum CodingKeys: String, CodingKey {
+        case source = "source"
+    }
+    
+    public init(source: String) {
+        self.source = source
+    }
+}

--- a/ProcessOut/Classes/CustomerTokenRequest.swift
+++ b/ProcessOut/Classes/CustomerTokenRequest.swift
@@ -9,9 +9,13 @@ import Foundation
 
 public class CustomerTokenRequest: Encodable {
     var source: String = ""
+    var verify: Bool = true
+    var threeDS2Enabled = true
     
     enum CodingKeys: String, CodingKey {
         case source = "source"
+        case verify = "verify"
+        case threeDS2Enabled = "enable_three_d_s_2"
     }
     
     public init(source: String) {

--- a/ProcessOut/Classes/FingerprintWebView.swift
+++ b/ProcessOut/Classes/FingerprintWebView.swift
@@ -1,0 +1,56 @@
+//
+//  FingerprintWebView.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 30/09/2019.
+//
+
+import Foundation
+
+class FingerprintWebView: ProcessOutWebView {
+    
+    public init(customerAction: CustomerAction, frame: CGRect, onResult: @escaping (String) -> Void, onAuthenticationError: @escaping () -> Void) {
+        super.init(frame: frame, onResult: onResult, onAuthenticationError: onAuthenticationError)
+        self.isHidden = true
+        
+        // Setup the fingerprint timeout handler
+        let timeOutHandler = DispatchWorkItem {
+            // Remove the webview
+            self.removeFromSuperview()
+
+            // Fallback to default fingerprint values
+            let fallback = self.generateFallbackFingerprintToken(URL: customerAction.value)
+            guard fallback.error == nil else {
+                onAuthenticationError()
+                return
+            }
+            onResult(fallback.fallbackToken!)
+        }
+        
+        // Start the timeout handler with a 10s timeout
+        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeOutHandler)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func generateFallbackFingerprintToken(URL: String) -> (fallbackToken: String?, error: ProcessOutException?) {
+        let miscGatewayRequest = MiscGatewayRequest(fingerprintResponse: "{\"threeDS2FingerprintTimeout\":true}")
+        miscGatewayRequest.headers = ["Content-Type": "application/json"]
+        miscGatewayRequest.url = URL
+        if let gatewayToken = miscGatewayRequest.generateToken() {
+            return (gatewayToken, nil)
+        } else {
+            return (nil, ProcessOutException.InternalError)
+        }
+    }
+    
+    override func onRedirect(url: URL) {
+        guard let parameters = url.queryParameters, let token = parameters["token"] else {
+            return
+        }
+        
+        onResult(token)
+    }
+}

--- a/ProcessOut/Classes/FingerprintWebView.swift
+++ b/ProcessOut/Classes/FingerprintWebView.swift
@@ -39,11 +39,12 @@ class FingerprintWebView: ProcessOutWebView {
         let miscGatewayRequest = MiscGatewayRequest(fingerprintResponse: "{\"threeDS2FingerprintTimeout\":true}")
         miscGatewayRequest.headers = ["Content-Type": "application/json"]
         miscGatewayRequest.url = URL
-        if let gatewayToken = miscGatewayRequest.generateToken() {
-            return (gatewayToken, nil)
-        } else {
+        
+        guard let gatewayToken = miscGatewayRequest.generateToken() else {
             return (nil, ProcessOutException.InternalError)
         }
+        
+        return (gatewayToken, nil)
     }
     
     override func onRedirect(url: URL) {

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -108,11 +108,11 @@ public class ProcessOut {
                 if let card = tokenizationResult.card, tokenizationResult.success {
                     completion(card.id, nil)
                 } else {
-                    if let message = tokenizationResult.message, let errorType = tokenizationResult.errorType {
-                        completion(nil, ProcessOutException.BadRequest(errorMessage: message, errorCode: errorType))
-                    } else {
+                    guard let message = tokenizationResult.message, let errorType = tokenizationResult.errorType else {
                         completion(nil, ProcessOutException.InternalError)
+                        return
                     }
+                    completion(nil, ProcessOutException.BadRequest(errorMessage: message, errorCode: errorType))
                 }
             } catch {
                 completion(nil, ProcessOutException.InternalError)

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -51,8 +51,9 @@ public class ProcessOut {
         }
     }
 
-    private static let ApiUrl: String = "https://api.processout.com"
-    internal static let CheckoutUrl: String = "https://checkout.processout.com"
+    static let ApiVersion: String = "v2.9.0"
+    private static let ApiUrl: String = "https://api.processout.ninja"
+    internal static let CheckoutUrl: String = "https://checkout.processout.ninja"
     internal static var ProjectId: String?
     internal static var UrlScheme: String?
     internal static let threeDS2ChallengeSuccess: String = "gway_req_eyJib2R5Ijoie1widHJhbnNTdGF0dXNcIjpcIllcIn0ifQ==";
@@ -443,6 +444,7 @@ public class ProcessOut {
             request.httpMethod = method.rawValue
             request.setValue("application/json", forHTTPHeaderField: "Content-Type")
             request.setValue(authorizationHeader.value, forHTTPHeaderField: authorizationHeader.key)
+            request.setValue("ProcessOut iOS-Bindings/" + ApiVersion, forHTTPHeaderField: "User-Agent")
             request.setValue(UUID().uuidString, forHTTPHeaderField: "Idempotency-Key")
             request.timeoutInterval = 15
             request.httpBody = try JSONSerialization.data(withJSONObject: parameters, options: [])

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -248,20 +248,24 @@ public class ProcessOut {
     public static func listAlternativeMethods(completion: @escaping ([AlternativeGateway]?, ProcessOutException?) -> Void) {
         HttpRequest(route: "/gateway-configurations?filter=alternative-payment-methods&expand_merchant_accounts=true", method: .get, parameters: [:]) { (gateways
             , e) in
-            if gateways != nil {
-                do {
-                    let result = try JSONDecoder().decode(AlternativeGatewaysResult.self, from: gateways!)
-                    if let gConfs = result.gatewayConfigurations {
-                        completion(gConfs, nil)
-                    } else {
-                        completion(nil, ProcessOutException.InternalError)
-                    }
-                } catch {
-                    completion(nil, ProcessOutException.GenericError(error: error))
-                }
-            } else {
+            guard gateways != nil else {
                 completion(nil, e)
+                return
             }
+            
+            var result: AlternativeGatewaysResult
+            do {
+                result = try JSONDecoder().decode(AlternativeGatewaysResult.self, from: gateways!)
+            } catch {
+                completion(nil, ProcessOutException.GenericError(error: error))
+                return
+            }
+            
+            if let gConfs = result.gatewayConfigurations {
+                completion(gConfs, nil)
+                return
+            }
+            completion(nil, ProcessOutException.InternalError)
         }
     }
     

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -52,10 +52,9 @@ public class ProcessOut {
     }
 
     static let ApiVersion: String = "v2.9.0"
-    private static let ApiUrl: String = "https://api.processout.ninja"
-    internal static let CheckoutUrl: String = "https://checkout.processout.ninja"
+    private static let ApiUrl: String = "https://api.processout.com"
+    internal static let CheckoutUrl: String = "https://checkout.processout.com"
     internal static var ProjectId: String?
-    internal static var UrlScheme: String?
     internal static let threeDS2ChallengeSuccess: String = "gway_req_eyJib2R5Ijoie1widHJhbnNTdGF0dXNcIjpcIllcIn0ifQ==";
     internal static let threeDS2ChallengeError: String = "gway_req_eyJib2R5Ijoie1widHJhbnNTdGF0dXNcIjpcIk5cIn0ifQ==";
     internal static let sessionManager = SessionManager()
@@ -63,11 +62,6 @@ public class ProcessOut {
 
     public static func Setup(projectId: String) {
         ProcessOut.ProjectId = projectId
-    }
-    
-    public static func Setup(projectId: String, urlScheme: String) {
-        ProcessOut.ProjectId = projectId
-        ProcessOut.UrlScheme = urlScheme
     }
     
     /// Tokenizes a card with metadata

--- a/ProcessOut/Classes/ProcessOutWebView.swift
+++ b/ProcessOut/Classes/ProcessOutWebView.swift
@@ -23,7 +23,7 @@ public class ProcessOutWebView: WKWebView, WKNavigationDelegate {
         self.onResult = onResult
         self.onAuthenticationError = onAuthenticationError
         super.init(frame: frame, configuration: config)
-        self.customUserAgent = "ProcessOut iOS-Webview/v2.9.0"
+        self.customUserAgent = "ProcessOut iOS-Webview/" + ProcessOut.ApiVersion
         self.navigationDelegate = self
     }
     

--- a/ProcessOut/Classes/ProcessOutWebView.swift
+++ b/ProcessOut/Classes/ProcessOutWebView.swift
@@ -1,0 +1,58 @@
+//
+//  ProcessOutWebView.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 30/09/2019.
+//
+
+import Foundation
+import WebKit
+
+public class ProcessOutWebView: WKWebView, WKNavigationDelegate {
+    private let REDIRECT_URL_PATTERN = "https:\\/\\/checkout\\.processout\\.(ninja|com)\\/helpers\\/mobile-processout-webview-landing.*"
+    internal var onResult: (_ token: String) -> Void
+    internal var onAuthenticationError: () -> Void
+    
+    public init(frame: CGRect, onResult: @escaping (String) -> Void, onAuthenticationError: @escaping () -> Void) {
+        // Setup up the webview to display the challenge
+        let config = WKWebViewConfiguration()
+        let preferences = WKPreferences()
+        preferences.javaScriptEnabled = true
+        config.preferences = preferences
+        
+        self.onResult = onResult
+        self.onAuthenticationError = onAuthenticationError
+        super.init(frame: frame, configuration: config)
+        self.customUserAgent = "ProcessOut iOS-Webview/v2.9.0"
+        self.navigationDelegate = self
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func onRedirect(url: URL) {
+        fatalError("Must override onRedirect")
+    }
+    
+    public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let url = webView.url else {
+            return
+        }
+        
+        if url.absoluteString.range(of: REDIRECT_URL_PATTERN, options: .regularExpression, range: nil, locale: nil) != nil {
+         self.onRedirect(url: url)
+        }
+    }
+}
+
+extension URL {
+    public var queryParameters: [String: String]? {
+        guard
+            let components = URLComponents(url: self, resolvingAgainstBaseURL: true),
+            let queryItems = components.queryItems else { return nil }
+        return queryItems.reduce(into: [String: String]()) { (result, item) in
+            result[item.name] = item.value
+        }
+    }
+}

--- a/ProcessOut/Classes/ProcessOutWebView.swift
+++ b/ProcessOut/Classes/ProcessOutWebView.swift
@@ -8,7 +8,7 @@
 import Foundation
 import WebKit
 
-public class ProcessOutWebView: WKWebView, WKNavigationDelegate {
+public class ProcessOutWebView: WKWebView, WKNavigationDelegate, WKUIDelegate {
     private let REDIRECT_URL_PATTERN = "https:\\/\\/checkout\\.processout\\.(ninja|com)\\/helpers\\/mobile-processout-webview-landing.*"
     internal var onResult: (_ token: String) -> Void
     internal var onAuthenticationError: () -> Void
@@ -25,6 +25,7 @@ public class ProcessOutWebView: WKWebView, WKNavigationDelegate {
         super.init(frame: frame, configuration: config)
         self.customUserAgent = "ProcessOut iOS-Webview/" + ProcessOut.ApiVersion
         self.navigationDelegate = self
+        self.uiDelegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -43,6 +44,12 @@ public class ProcessOutWebView: WKWebView, WKNavigationDelegate {
         if url.absoluteString.range(of: REDIRECT_URL_PATTERN, options: .regularExpression, range: nil, locale: nil) != nil {
          self.onRedirect(url: url)
         }
+    }
+    
+    public func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration, for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures)-> WKWebView? {
+        // Add support for popups/new tabs
+        webView.load(navigationAction.request)
+        return nil
     }
 }
 

--- a/ProcessOut/Classes/ThreeDSHandler.swift
+++ b/ProcessOut/Classes/ThreeDSHandler.swift
@@ -21,6 +21,12 @@ public protocol ThreeDSHandler {
     ///   - completion: Callback specifying wheter or not the challenge was successful
     func doChallenge(authentificationData: AuthentificationChallengeData, completion: @escaping (Bool) -> Void)
     
+    
+    /// Method called when a web challenge is required
+    ///
+    /// - Parameter webView: The webView to present
+    func doPresentWebView(webView: ProcessOutWebView)
+    
     /// Called when the authorization was successful
     ///
     /// - Parameter invoiceId: Invoice id that was authorized
@@ -60,6 +66,10 @@ public class ThreeDSTestHandler: ThreeDSHandler {
         self.controller.present(alert, animated: true)
     }
     
+    public func doPresentWebView(webView: ProcessOutWebView) {
+        controller.view.addSubview(webView)
+    }
+    
     public func onSuccess(invoiceId: String) {
         self.completion(invoiceId, nil)
     }
@@ -67,6 +77,4 @@ public class ThreeDSTestHandler: ThreeDSHandler {
     public func onError(error: ProcessOutException) {
         self.completion(nil, error)
     }
-    
-    
 }

--- a/ProcessOut/Classes/TokenRequest.swift
+++ b/ProcessOut/Classes/TokenRequest.swift
@@ -9,11 +9,12 @@ import Foundation
 
 class TokenRequest: Encodable {
     var source: String = ""
-    var verify: Bool = true
-    
+    var verify = true
+    var enable3DS2 = true
     enum CodingKeys: String, CodingKey {
         case source = "source"
         case verify = "verify"
+        case enable3DS2 = "enable_three_d_s_2"
     }
     
     init(source: String) {

--- a/ProcessOut/Classes/TokenRequest.swift
+++ b/ProcessOut/Classes/TokenRequest.swift
@@ -9,9 +9,11 @@ import Foundation
 
 class TokenRequest: Encodable {
     var source: String = ""
+    var verify: Bool = true
     
     enum CodingKeys: String, CodingKey {
         case source = "source"
+        case verify = "verify"
     }
     
     init(source: String) {

--- a/ProcessOut/Classes/TokenRequest.swift
+++ b/ProcessOut/Classes/TokenRequest.swift
@@ -1,0 +1,20 @@
+//
+//  TokenRequest.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 19/09/2019.
+//
+
+import Foundation
+
+class TokenRequest: Encodable {
+    var source: String = ""
+    
+    enum CodingKeys: String, CodingKey {
+        case source = "source"
+    }
+    
+    init(source: String) {
+        self.source = source
+    }
+}


### PR DESCRIPTION
# Migration

## SDK setup
Specifying a custom URL scheme is no longer required. Instantiate the SDK like so in your `AppDelegate`:
```swift
ProcessOut.Setup(projectId: "project-id")
```

## Payment instantiation
Use the `makeCardPayment` or `makeCardToken` methods like in `v2.8.2`.

```swift
ProcessOut.makeCardPayment(invoiceId: "invoice-id", token: token!, handler: ProcessOut.createThreeDSTestHandler(viewController: self, completion: { (invoiceId, error) in
    // If error is nil, send the invoice to your backend to complete the charge
}), with: self)
```

The only change relies in the `ThreeDSHandler` protocol:

A new method has to be overridden (**See the full protocol at the bottom of the PR**):
```swift
public func doPresentWebView(webView: ProcessOutWebView) {
    // Called when a web challenge is required
    // Present the webView to your user the way you want
}
```

## Deep-links (APM purposes)
The only case where your user might come back from the device browser is when dealing with Alternative Payment Methods.
In your `AppDelegate` file:

```swift
// This method handles opening custom URL schemes (e.g., "yourapp://")
func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
    if let token = ProcessOut.handleURLCallback(url: url) {
        // Send the token to your backend to complete the charge
    }
    return false
}
```

### Full `ThreeDSHandler` protocol:

```swift
/// Custom protocol which lets you implement a 3DS2 integration
public protocol ThreeDSHandler {
    /// method called when a device fingerprint is required
    ///
    /// - Parameters:
    ///   - directoryServerData: Contains information required by the third-party handling the device fingerprinting
    ///   - completion: Callback containing the fingerprint information
    func doFingerprint(directoryServerData: DirectoryServerData, completion: @escaping (ThreeDSFingerprintResponse) -> Void)
    
    /// Method called when a 3DS2 challenge is required
    ///
    /// - Parameters:
    ///   - authentificationData: Authentification data required to present the challenge
    ///   - completion: Callback specifying wheter or not the challenge was successful
    func doChallenge(authentificationData: AuthentificationChallengeData, completion: @escaping (Bool) -> Void)
    
    
    /// Method called when a web challenge is required
    ///
    /// - Parameter webView: The webView to present
    func doPresentWebView(webView: ProcessOutWebView)
    
    /// Called when the authorization was successful
    ///
    /// - Parameter invoiceId: Invoice id that was authorized
    func onSuccess(invoiceId: String)
    
    /// Called when the authorization process ends up in a failed state.
    ///
    /// - Parameter error: Error
    func onError(error: ProcessOutException)
}
```