### PR TITLE
APM: add support for APM tokens

### DIFF
--- a/Example/ProcessOut/AppDelegate.swift
+++ b/Example/ProcessOut/AppDelegate.swift
@@ -23,8 +23,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     // This method handles opening native URLs (e.g., "yourapp://")
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if let token = ProcessOut.handleURLCallback(url: url) {
-            print(token)
+        if let apmReturn = ProcessOut.handleAPMURLCallback(url: url) {
+            print(apmReturn.returnType)
         }
         return false
     }

--- a/Example/ProcessOut/AppDelegate.swift
+++ b/Example/ProcessOut/AppDelegate.swift
@@ -24,7 +24,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // This method handles opening native URLs (e.g., "yourapp://")
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         if let apmReturn = ProcessOut.handleAPMURLCallback(url: url) {
-            print(apmReturn.returnType)
+            guard apmReturn.error == nil else {
+                // Error while parsing the URL
+                return false
+            }
+            
+            switch apmReturn.returnType {
+            case .Authorization:
+                // Finish the charge on your backend with apmReturn.token
+                break
+            case .CreateToken:
+                // Update the customer token on your backend with source: apmReturn.token and apmReturn.customerId, apmReturn.tokenId
+                break
+            }
         }
         return false
     }

--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -84,12 +84,11 @@ class ProcessOutUITests: XCTestCase {
     func testApmListing() {
         let expectation = XCTestExpectation(description: "List available APM")
         
-        ProcessOut.listAlternativeMethods(completion: {(gateways, error) in
-            
+        ProcessOut.fetchGatewayConfigurations(filter: .AlternativePaymentMethods) { (gateways, error) in
             XCTAssertNotNil(gateways)
             
             expectation.fulfill()
-        })
+        }
         
         wait(for: [expectation], timeout: 10.0)
     }

--- a/ProcessOut.podspec
+++ b/ProcessOut.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ProcessOut'
-  s.version          = '2.9.0'
+  s.version          = '2.10.0'
   s.summary          = 'The smart router for payments. Smartly route each transaction to the relevant payment providers.'
 
 # This description is used to generate tags and improve search results.

--- a/ProcessOut/Classes/APMTokenReturn.swift
+++ b/ProcessOut/Classes/APMTokenReturn.swift
@@ -1,0 +1,38 @@
+//
+//  APMTokenReturn.swift
+//  ProcessOut
+//
+//  Created by Jeremy Lejoux on 31/10/2019.
+//
+
+import Foundation
+
+public class APMTokenReturn {
+    public enum APMReturnType {
+        case Authorization
+        case CreateToken
+    }
+    
+    public var token: String?
+    public var customerId: String?
+    public var tokenId: String?
+    public var returnType: APMReturnType
+    public var error: ProcessOutException?
+    
+    public init(token: String) {
+        self.token = token
+        self.returnType = .Authorization
+    }
+    
+    public init(token: String, customerId: String, tokenId: String) {
+        self.token = token
+        self.customerId = customerId
+        self.tokenId = tokenId
+        self.returnType = .CreateToken
+    }
+    
+    public init(error: ProcessOutException) {
+        self.error = error
+        self.returnType = .Authorization
+    }
+}

--- a/ProcessOut/Classes/GatewayConfiguration.swift
+++ b/ProcessOut/Classes/GatewayConfiguration.swift
@@ -42,17 +42,9 @@ public class GatewayConfiguration: Decodable {
         self.enabled = enabled
         self.gateway = gateway
     }
-    
-    public func getRedirectURL(invoiceId: String) -> NSURL? {
-        let checkout = ProcessOut.ProjectId! + "/" + invoiceId + "/redirect/" + self.id
-        if let url = NSURL(string: ProcessOut.CheckoutUrl + "/" + checkout) {
-            return url
-        }
-        return nil
-    }
 }
 
-class AlternativeGatewaysResult: ApiResponse {
+class GatewayConfigurationResult: ApiResponse {
     var gatewayConfigurations: [GatewayConfiguration]?
     
     enum CodingKeys: String, CodingKey {

--- a/ProcessOut/Classes/GatewayConfiguration.swift
+++ b/ProcessOut/Classes/GatewayConfiguration.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class AlternativeGateway: Decodable {
+public class GatewayConfiguration: Decodable {
     
     enum CodingKeys: String, CodingKey {
         case id = "id"
@@ -53,7 +53,7 @@ public class AlternativeGateway: Decodable {
 }
 
 class AlternativeGatewaysResult: ApiResponse {
-    var gatewayConfigurations: [AlternativeGateway]?
+    var gatewayConfigurations: [GatewayConfiguration]?
     
     enum CodingKeys: String, CodingKey {
         case gatewayConfigurations = "gateway_configurations"
@@ -61,7 +61,7 @@ class AlternativeGatewaysResult: ApiResponse {
     
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.gatewayConfigurations = try container.decode([AlternativeGateway].self, forKey: .gatewayConfigurations)
+        self.gatewayConfigurations = try container.decode([GatewayConfiguration].self, forKey: .gatewayConfigurations)
         try super.init(from: decoder)
     }
 }

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -248,11 +248,17 @@ public class ProcessOut {
     }
     
     
+    public enum GatewayConfigurationsFilter: String {
+        case All = ""
+        case AlternativePaymentMethods = "alternative-payment-methods"
+        case AlternativePaymentMethodWithTokenization = " alternative-payment-methods-with-tokenization"
+    }
+    
     /// List alternative gateway configurations activated on your account
     ///
     /// - Parameter completion: Completion callback
-    public static func listAlternativeMethods(completion: @escaping ([AlternativeGateway]?, ProcessOutException?) -> Void) {
-        HttpRequest(route: "/gateway-configurations?filter=alternative-payment-methods&expand_merchant_accounts=true", method: .get, parameters: [:]) { (gateways
+    public static func fetchGatewayConfigurations(filter: GatewayConfigurationsFilter, completion: @escaping ([GatewayConfiguration]?, ProcessOutException?) -> Void) {
+        HttpRequest(route: "/gateway-configurations?filter=" + filter.rawValue + "&expand_merchant_accounts=true", method: .get, parameters: [:]) { (gateways
             , e) in
             guard gateways != nil else {
                 completion(nil, e)
@@ -451,7 +457,7 @@ public class ProcessOut {
     ///   - gateway: The alternative payment method configuration
     ///   - customerId: The customer ID
     ///   - tokenId: The token ID generated on your backend with an empty source
-    public static func makeAPMToken(gateway: AlternativeGateway, customerId: String, tokenId: String) {
+    public static func makeAPMToken(gateway: GatewayConfiguration, customerId: String, tokenId: String) {
         // Generate the redirection URL
         let checkout = ProcessOut.ProjectId! + "/" + customerId + "/" + tokenId + "/redirect/" + gateway.id
         if let url = NSURL(string: ProcessOut.CheckoutUrl + "/" + checkout) {

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -408,26 +408,6 @@ public class ProcessOut {
     public static func createThreeDSTestHandler(viewController: UIViewController, completion: @escaping (String?, ProcessOutException?) -> Void) -> ThreeDSHandler {
         return ThreeDSTestHandler(controller: viewController, completion: completion)
     }
-
-    public static func continueThreeDSVerification(invoiceId: String, token: String, completion: @escaping (String?, ProcessOutException?) -> Void) {
-        let authRequest = AuthorizationRequest(source: token)
-        if let body = try? JSONEncoder().encode(authRequest) {
-            do {
-                let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
-                HttpRequest(route: "/invoices/" + invoiceId + "/authorize", method: .post, parameters: json, completion: {(data, error) -> Void in
-                    if data != nil {
-                        completion(invoiceId, nil)
-                    } else {
-                        completion(nil, error!)
-                    }
-                })
-            } catch {
-                completion(nil, ProcessOutException.GenericError(error: error))
-            }
-        } else {
-            completion(nil, ProcessOutException.InternalError)
-        }
-    }
     
     private static func HttpRequest(route: String, method: HTTPMethod, parameters: Parameters, completion: @escaping (Data?, ProcessOutException?) -> Void) {
         guard let projectId = ProjectId, let authorizationHeader = Request.authorizationHeader(user: projectId, password: "") else {

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -265,9 +265,9 @@ public class ProcessOut {
                 return
             }
             
-            var result: AlternativeGatewaysResult
+            var result: GatewayConfigurationResult
             do {
-                result = try JSONDecoder().decode(AlternativeGatewaysResult.self, from: gateways!)
+                result = try JSONDecoder().decode(GatewayConfigurationResult.self, from: gateways!)
             } catch {
                 completion(nil, ProcessOutException.GenericError(error: error))
                 return
@@ -460,6 +460,19 @@ public class ProcessOut {
     public static func makeAPMToken(gateway: GatewayConfiguration, customerId: String, tokenId: String) {
         // Generate the redirection URL
         let checkout = ProcessOut.ProjectId! + "/" + customerId + "/" + tokenId + "/redirect/" + gateway.id
+        if let url = NSURL(string: ProcessOut.CheckoutUrl + "/" + checkout) {
+            UIApplication.shared.openURL(url as URL)
+        }
+    }
+    
+    /// Initiate an alternative payment method payment
+    ///
+    /// - Parameters:
+    ///   - gateway: Gateway to use (previously fetched)
+    ///   - invoiceId: Invoice ID generated on your backend
+    public static func makeAPMPayment(gateway: GatewayConfiguration, invoiceId: String) {
+        // Generate the redirection URL
+        let checkout = ProcessOut.ProjectId! + "/" + invoiceId + "/redirect/" + gateway.id
         if let url = NSURL(string: ProcessOut.CheckoutUrl + "/" + checkout) {
             UIApplication.shared.openURL(url as URL)
         }

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -393,6 +393,7 @@ public class ProcessOut {
     ///
     /// - Parameter url: Deeplink opened
     /// - Returns: A gateway token string if available, nil if not a ProcessOut URL or not available
+    @available(*, deprecated, message: "Use handleAPMURLCallback instead.")
     public static func handleURLCallback(url: URL) -> String? {
         guard let host = url.host, host == "processout.return", let parameters = url.queryParameters else {
             return nil

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -51,7 +51,7 @@ public class ProcessOut {
         }
     }
 
-    static let ApiVersion: String = "v2.9.0"
+    static let ApiVersion: String = "v2.10.0"
     private static let ApiUrl: String = "https://api.processout.com"
     internal static let CheckoutUrl: String = "https://checkout.processout.com"
     internal static var ProjectId: String?


### PR DESCRIPTION
# APM
It is now possible to create an APM token for customer token.

## Preparing a customer token
Refer to the [documentation to create a customer token](https://docs.processout.com/payments/save-token-and-capture-later/#step-2:-create-a-customer-token) **with an empty source**.

Also, during the token creation call, specify a `return_url` with your app scheme and `processout.return` as host.
Ex: `yourapp://processout.return`
This will allow your user to re-open the app once the APM verification is completed.

## Initiating an APM token creation

First list your available APM gateways:
```swift
ProcessOut.fetchGatewayConfigurations(filter: .AlternativePaymentMethodWithTokenization) { (gateways, error) in
    // Check for errors
}
```

Then if completed, you can directly start a tokenization for a specific APM:
```swift

ProcessOut.fetchGatewayConfigurations(filter: .AlternativePaymentMethodWithTokenization) { (gateways, error) in
    ProcessOut.makeAPMToken(gateway: gateways![0], customerId: "customer-id", tokenId: "token-id")
}
```

## Handling the user coming back to the app
Then in your `AppDelegate` file handle the user return like so:

```swift
// This method handles opening native URLs (e.g., "yourapp://")
    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
        if let apmReturn = ProcessOut.handleAPMURLCallback(url: url) {
            guard apmReturn.error == nil else {
                // Error while parsing the URL
                return false
            }
            
            switch apmReturn.returnType {
            case .Authorization:
                // Finish the charge on your backend with apmReturn.token
                break
            case .CreateToken:
                // Update the customer token on your backend with source: apmReturn.token and apmReturn.customerId, apmReturn.tokenId
                break
            }
        }
        return false
    }
```