### PR TITLE
apm-url: add new method to return redirect URL

### DIFF
--- a/ProcessOut.podspec
+++ b/ProcessOut.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ProcessOut'
-  s.version          = '2.10.2'
+  s.version          = '2.10.3'
   s.summary          = 'The smart router for payments. Smartly route each transaction to the relevant payment providers.'
 
 # This description is used to generate tags and improve search results.

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -468,20 +468,34 @@ public class ProcessOut {
         }
     }
     
-    /// Initiate an alternative payment method payment
+    /// Initiate an alternative payment method payment by opening the default browser
     ///
     /// - Parameters:
     ///   - gateway: Gateway to use (previously fetched)
     ///   - invoiceId: Invoice ID generated on your backend
+    @available(*, deprecated)
     public static func makeAPMPayment(gateway: GatewayConfiguration, invoiceId: String, additionalData: [String: String] = [:]) {
+        // Generate the redirection URL
+        let urlString: String = makeAPMPayment(gateway: gateway, invoiceId: invoiceId, additionalData: additionalData)
+        
+        if let url = NSURL(string: urlString) {
+            UIApplication.shared.openURL(url as URL)
+        }
+    }
+    
+    /// Returns the URL to initiate an alternative payment method payment
+    ///
+    /// - Parameters:
+    ///   - gateway: Gateway to use (previously fetched)
+    ///   - invoiceId: Invoice ID generated on your backend
+    /// - Returns: Redirect URL that should be displayed in a webview
+    public static func makeAPMPayment(gateway: GatewayConfiguration, invoiceId: String, additionalData: [String: String] = [:]) -> String {
         // Generate the redirection URL
         let checkout = ProcessOut.ProjectId! + "/" + invoiceId + "/redirect/" + gateway.id
         let additionalDataString = generateAdditionalDataString(additionalData: additionalData)
         let urlString = ProcessOut.CheckoutUrl + "/" + checkout + additionalDataString
         
-        if let url = NSURL(string: urlString) {
-            UIApplication.shared.openURL(url as URL)
-        }
+        return urlString
     }
     
     


### PR DESCRIPTION
## Context
When initiating an APM payment, the user has to be redirected to a specific URL.
Currently, this URL is opened by the ProcessOut SDK within the default web browser of the device.

This causes some unexpected states depending on user behavior. 

## Solution
Returning the URL to the merchant app allows the merchant to directly embed the APM page within a webview if needed.