### PR TITLE
Gateway configurations: Implement pagination over gateway configurations

### DIFF
--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -72,6 +72,21 @@ class ProcessOutUITests: XCTestCase {
         wait(for: [expectation], timeout: 10.0)
     }
     
+    // Test that a successful response is returned from the gateway configurations endpoint when pagination is requested
+    func testGatewayConfigurationListingWithPagination() {
+        XCUIApplication().launch()
+        
+        let expectation = XCTestExpectation(description: "Fetch gateway configurations with pagination options")
+        
+        ProcessOut.fetchGatewayConfigurations(filter: .All, paginationOptions: ProcessOut.PaginationOptions(StartAfter: "1234", Limit: 20, Order: "asc")) { (gateways, error) in
+            XCTAssertNotNil(gateways)
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 10.0)
+    }
+    
     // Test 3DS2 web payment
     func test3DS2WebPayment() {
         let app = XCUIApplication()

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -51,6 +51,20 @@ public class ProcessOut {
         }
     }
 
+    public struct PaginationOptions {
+        var StartAfter: String?
+        var EndBefore: String?
+        var Limit: Int?
+        var Order: String?
+
+        public init(StartAfter: String? = nil, EndBefore: String? = nil, Limit: Int? = nil, Order: String? = nil) {
+            self.StartAfter = StartAfter
+            self.EndBefore = EndBefore
+            self.Limit = Limit
+            self.Order = Order
+        }
+    }
+
     static let ApiVersion: String = "v2.10.1"
     private static let ApiUrl: String = "https://api.processout.com"
     internal static let CheckoutUrl: String = "https://checkout.processout.com"

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -554,22 +554,19 @@ public class ProcessOut {
     /// - Returns: An empty string or a string containing a set of query parameters.
     /// Note that the returned string is not prefixed or suffixed with ? or &, so you may need to do this yourself depending on where these parameters will appear in your URL
     private static func generatePaginationParamsString(paginationOptions: PaginationOptions) -> String {
-        // Construct the individual query params
-        let startAfterParam = paginationOptions.StartAfter != nil ? "start_after=" + paginationOptions.StartAfter! + "&" : ""
-        let endBeforeParam = paginationOptions.EndBefore != nil ? "end_before=" + paginationOptions.EndBefore! + "&" : ""
-        let limitParam = paginationOptions.Limit != nil ? "limit=" + String(paginationOptions.Limit!) + "&" : ""
-        let orderParam = paginationOptions.Order != nil ? "order=" + paginationOptions.Order! : ""
+        // Construct the individual query params and store them in an array
+        let paginationParams: [String?] = [
+            paginationOptions.StartAfter != nil ? "start_after=" + paginationOptions.StartAfter! : nil,
+            paginationOptions.EndBefore != nil ? "end_before=" + paginationOptions.EndBefore! : nil,
+            paginationOptions.Limit != nil ? "limit=" + String(paginationOptions.Limit!) : nil,
+            paginationOptions.Order != nil ? "order=" + paginationOptions.Order! : nil
+        ]
 
-        // Combine the individual query params into a single string
-        let paginationParams = startAfterParam + endBeforeParam + limitParam + orderParam
+        // Remove any nil values from the array
+        let filteredPaginationParams = paginationParams.flatMap {$0}
 
-        // Check if the combined query params have a trailing ampersand
-        if paginationParams.hasSuffix("&") {
-            // If there is a trailing ampersand, return the combined query params with the last character removed
-            return String(paginationParams.prefix(paginationParams.count - 1))
-        }
-        // If there is no trailing ampersand, return the combined query params
-        return paginationParams
+        // Join the array into a single string separated by ampersands and return it
+        return filteredPaginationParams.joined(separator: "&")
     }
 
     private static func HttpRequest(route: String, method: HTTPMethod, parameters: Parameters?, completion: @escaping (Data?, ProcessOutException?) -> Void) {

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -270,9 +270,13 @@ public class ProcessOut {
     
     /// List alternative gateway configurations activated on your account
     ///
-    /// - Parameter completion: Completion callback
-    public static func fetchGatewayConfigurations(filter: GatewayConfigurationsFilter, completion: @escaping ([GatewayConfiguration]?, ProcessOutException?) -> Void) {
-        HttpRequest(route: "/gateway-configurations?filter=" + filter.rawValue + "&expand_merchant_accounts=true", method: .get, parameters: nil) { (gateways
+    /// - Parameters:
+    ///   - completion: Completion callback
+    ///   - paginationOptions: Pagination options to use
+    public static func fetchGatewayConfigurations(filter: GatewayConfigurationsFilter, completion: @escaping ([GatewayConfiguration]?, ProcessOutException?) -> Void, paginationOptions: PaginationOptions? = nil) {
+        let paginationParams = paginationOptions != nil ? "&" + generatePaginationParamsString(paginationOptions: paginationOptions!) : ""
+
+        HttpRequest(route: "/gateway-configurations?filter=" + filter.rawValue + "&expand_merchant_accounts=true" + paginationParams, method: .get, parameters: nil) { (gateways
             , e) in
             guard gateways != nil else {
                 completion(nil, e)

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -543,6 +543,31 @@ public class ProcessOut {
         })
     }
     
+    /// Generates a query parameter string to facilitate pagination on many endpoints.
+    /// For more information, see https://docs.processout.com/refs/#pagination
+    ///
+    /// - Parameter paginationOptions: Pagination options to use
+    /// - Returns: An empty string or a string containing a set of query parameters.
+    /// Note that the returned string is not prefixed or suffixed with ? or &, so you may need to do this yourself depending on where these parameters will appear in your URL
+    private static func generatePaginationParamsString(paginationOptions: PaginationOptions) -> String {
+        // Construct the individual query params
+        let startAfterParam = paginationOptions.StartAfter != nil ? "start_after=" + paginationOptions.StartAfter! + "&" : ""
+        let endBeforeParam = paginationOptions.EndBefore != nil ? "end_before=" + paginationOptions.EndBefore! + "&" : ""
+        let limitParam = paginationOptions.Limit != nil ? "limit=" + String(paginationOptions.Limit!) + "&" : ""
+        let orderParam = paginationOptions.Order != nil ? "order=" + paginationOptions.Order! : ""
+
+        // Combine the individual query params into a single string
+        let paginationParams = startAfterParam + endBeforeParam + limitParam + orderParam
+
+        // Check if the combined query params have a trailing ampersand
+        if paginationParams.hasSuffix("&") {
+            // If there is a trailing ampersand, return the combined query params with the last character removed
+            return String(paginationParams.prefix(paginationParams.count - 1))
+        }
+        // If there is no trailing ampersand, return the combined query params
+        return paginationParams
+    }
+
     private static func HttpRequest(route: String, method: HTTPMethod, parameters: Parameters?, completion: @escaping (Data?, ProcessOutException?) -> Void) {
         guard let projectId = ProjectId, let authorizationHeader = Request.authorizationHeader(user: projectId, password: "") else {
             completion(nil, ProcessOutException.MissingProjectId)


### PR DESCRIPTION
### Description
Gateway configurations, like most listable resources on ProcessOut, support [cursor-based pagination](https://docs.processout.com/refs/#pagination). Currently `processout-ios` provides no way of specifying pagination options, so this PR implements this functionality.

Specifying pagination options is done by passing `fetchGatewayConfigurations` an instance of the new `PaginationOptions` `struct`. Defining the pagination options this way makes it easy to take advantage of Swift's type safety features and encourages code reuse, which will make it easier to implement similar functionality on other parts of the codebase in the future.