### PR TITLE
Disable URL caching

### DIFF
--- a/Example/ProcessOut/ViewController.swift
+++ b/Example/ProcessOut/ViewController.swift
@@ -66,7 +66,7 @@ class ViewController: UIViewController, PKPaymentAuthorizationViewControllerDele
         }
         
         let contact = ProcessOut.Contact(address1: "1 great street", address2: nil, city: "City", state: "State", zip: "10000", countryCode: "US")
-        let card = ProcessOut.Card(cardNumber: cardNumber, expMonth: 10, expYear: 20, cvc: "737", name: "Mr", contact: contact)
+        let card = ProcessOut.Card(cardNumber: cardNumber, expMonth: 10, expYear: 24, cvc: "737", name: "Mr", contact: contact)
         // Create invoice
         let inv = Invoice(name: "test 3DS", amount: "12.01", currency: "EUR")
         createInvoice(invoice: inv, completion: {(invoiceId, error) in

--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -47,7 +47,7 @@ class ProcessOutUITests: XCTestCase {
         // Create an expectation for a background download task.
         let expectation = XCTestExpectation(description: "Tokenize a card")
         
-        let card = ProcessOut.Card(cardNumber: "424242424242", expMonth: 11, expYear: 20, cvc: "123", name: "test card")
+        let card = ProcessOut.Card(cardNumber: "424242424242", expMonth: 11, expYear: 24, cvc: "123", name: "test card")
         ProcessOut.Tokenize(card: card, metadata: [:], completion: {(token, error) in
             XCTAssertNotNil(token)
             expectation.fulfill()

--- a/ProcessOut/Classes/ProcessOutRequestManager.swift
+++ b/ProcessOut/Classes/ProcessOutRequestManager.swift
@@ -24,6 +24,7 @@ final class ProcessOutRequestManager {
         self.defaultUserAgent = defaultUserAgent
         self.urlSessionConfiguration = URLSessionConfiguration.default
         self.urlSessionConfiguration.urlCache = nil
+        self.urlSessionConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
         
         let retryPolicy = RetryPolicy()
         self.retryPolicy = retryPolicy

--- a/ProcessOut/Classes/ProcessOutRequestManager.swift
+++ b/ProcessOut/Classes/ProcessOutRequestManager.swift
@@ -22,7 +22,7 @@ final class ProcessOutRequestManager {
         self.apiUrl = apiUrl
         self.apiVersion = apiVersion
         self.defaultUserAgent = defaultUserAgent
-        self.urlSessionConfiguration = URLSessionConfiguration.default
+        self.urlSessionConfiguration = .default
         self.urlSessionConfiguration.urlCache = nil
         self.urlSessionConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
         

--- a/ProcessOut/Classes/ProcessOutRequestManager.swift
+++ b/ProcessOut/Classes/ProcessOutRequestManager.swift
@@ -16,11 +16,14 @@ final class ProcessOutRequestManager {
     let sessionDelegate: SessionDelegate
     let retryPolicy: RetryPolicy
     let urlSession: URLSession
+    let urlSessionConfiguration: URLSessionConfiguration
     
     init(apiUrl: String, apiVersion: String, defaultUserAgent: String) {
         self.apiUrl = apiUrl
         self.apiVersion = apiVersion
         self.defaultUserAgent = defaultUserAgent
+        self.urlSessionConfiguration = URLSessionConfiguration.default
+        self.urlSessionConfiguration.urlCache = nil
         
         let retryPolicy = RetryPolicy()
         self.retryPolicy = retryPolicy
@@ -29,7 +32,7 @@ final class ProcessOutRequestManager {
         sessionDelegate.retrier = retryPolicy
         self.sessionDelegate = sessionDelegate
         
-        self.urlSession = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: .main)
+        self.urlSession = URLSession(configuration: self.urlSessionConfiguration, delegate: sessionDelegate, delegateQueue: .main)
     }
     
     func HttpRequest(route: String, method: HTTPMethod, parameters: [String: Any]?, completion: @escaping (Data?, ProcessOutException?) -> Void) {


### PR DESCRIPTION
### Description
The aim of this PR is to disable URL caching for all requests made by the ProcessOut iOS SDK by manually setting the [`urlCache`](https://developer.apple.com/documentation/foundation/urlsessionconfiguration/1410148-urlcache) on the shared [`urlSession`](https://developer.apple.com/documentation/foundation/urlsession) object. This is to prevent potentially sensitive information being cached in the memory of the client device.