### PR TITLE
Implement incremental authorizations support

### DIFF
--- a/Example/ProcessOut_UITests/ProcessOut_UITests.swift
+++ b/Example/ProcessOut_UITests/ProcessOut_UITests.swift
@@ -93,7 +93,7 @@ class ProcessOutUITests: XCTestCase {
             self.createInvoice(invoice: inv, completion: {(invoiceId, error) in
                 XCTAssertNotNil(invoiceId)
                 
-                ProcessOut.makeCardPayment(invoiceId: invoiceId!, token: token!, incremental: true, handler: makeCardPaymentHandler, with: UIViewController())
+                ProcessOut.makeIncrementalAuthorizationPayment(invoiceId: invoiceId!, token: token!, handler: makeCardPaymentHandler, with: UIViewController())
             })
         })
         

--- a/IncrementAuthorizationRequest.swift
+++ b/IncrementAuthorizationRequest.swift
@@ -1,0 +1,10 @@
+//
+//  IncrementAuthorizationRequest.swift
+//  ProcessOut
+//
+//  Created by Seb Preston on 11/08/2021.
+//
+
+struct IncrementAuthorizationRequest: Codable {
+    var amount: Int
+}

--- a/ProcessOut/Classes/AuthorizationRequest.swift
+++ b/ProcessOut/Classes/AuthorizationRequest.swift
@@ -7,14 +7,17 @@
 
 class AuthorizationRequest: Codable {
     var source: String = ""
+    var incremental: Bool = false
     var threeDS2Enabled: Bool = true
     
     enum CodingKeys: String, CodingKey {
         case source = "source"
+        case incremental = "incremental"
         case threeDS2Enabled = "enable_three_d_s_2"
     }
     
-    init(source: String) {
+    init(source: String, incremental: Bool) {
         self.source = source
+        self.incremental = incremental
     }
 }

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -612,7 +612,7 @@ public class ProcessOut {
     private static func makeAuthorizationRequest(invoiceId: String, json: [String: Any], handler: ThreeDSHandler, with: UIViewController, actionHandlerCompletion: @escaping (String) -> Void) -> Void {
         HttpRequest(route: "/invoices/" + invoiceId + "/authorize", method: .post, parameters: json, completion: {(data, error) -> Void in
             guard data != nil else {
-                handler.onError(error: error!)
+                handler.onError(error: error ?? ProcessOutException.InternalError)
                 return
             }
             

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -325,7 +325,10 @@ public class ProcessOut {
         }
         
         do {
-            let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
+            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+                handler.onError(error: ProcessOutException.InternalError)
+                return
+            }
             makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
                 makeCardPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
             })
@@ -349,7 +352,10 @@ public class ProcessOut {
         }
         
         do {
-            let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
+            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+                handler.onError(error: ProcessOutException.InternalError)
+                return
+            }
             makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
                 makeIncrementalAuthorizationPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
             })
@@ -372,7 +378,10 @@ public class ProcessOut {
         }
         
         do {
-            let json = try JSONSerialization.jsonObject(with: body, options: []) as! [String : Any]
+            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+                handler.onError(error: ProcessOutException.InternalError)
+                return
+            }
             HttpRequest(route: "/invoices/" + invoiceId + "/increment_authorization", method: .post, parameters: json, completion: {(data, error) -> Void in
                 guard data != nil else {
                     handler.onError(error: error!)
@@ -609,7 +618,7 @@ public class ProcessOut {
     ///   - handler: Custom 3DS2 handler (please refer to our documentation for this)
     ///   - with: UIViewController to display webviews and perform fingerprinting
     ///   - actionHandlerCompletion: Callback to pass to action handler to be executed following web authentication
-    private static func makeAuthorizationRequest(invoiceId: String, json: [String: Any], handler: ThreeDSHandler, with: UIViewController, actionHandlerCompletion: @escaping (String) -> Void) -> Void {
+    private static func makeAuthorizationRequest(invoiceId: String, json: [String: Any]?, handler: ThreeDSHandler, with: UIViewController, actionHandlerCompletion: @escaping (String) -> Void) -> Void {
         HttpRequest(route: "/invoices/" + invoiceId + "/authorize", method: .post, parameters: json, completion: {(data, error) -> Void in
             guard data != nil else {
                 handler.onError(error: error ?? ProcessOutException.InternalError)


### PR DESCRIPTION
## Description
A new feature was recently implemented on the ProcessOut API that enables users to create authorizations where the value can be incremented at a later time. This PR makes it possible to utilize this feature from the `ProcessOut` pod.

## Solution
This PR adds an optional `incremental` parameter to the `makeCardPayment` function that will mark the resulting authorization as incremental. Once this has been done a newly implemented function, `incrementAuthorizationAmount`, can be used to increment the authorization by a provided amount. In addition, unit tests have been implemented to demonstrate this workflow.