### PR TITLE
Fix forced unwrap of http tokenization result

### DIFF
--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -235,7 +235,7 @@ public class ProcessOut {
                     guard let tokenResponse = tokenResponse else {
                         throw ProcessOutException.InternalError
                     }
-                    let tokenizationResult = try JSONDecoder().decode(TokenizationResult.self, from: tokenResponse!)
+                    let tokenizationResult = try JSONDecoder().decode(TokenizationResult.self, from: tokenResponse)
                     if let card = tokenizationResult.card, tokenizationResult.success {
                         completion(card.id, nil)
                     } else {


### PR DESCRIPTION
As part of a past change (#32), a `guard` was implemented in the `HttpRequest` call of the `Tokenize` method, meaning the `tokenResponse` object became a non-optional type. As a result, the following line where it is force unwrapped caused an error. This PR fixes this error by removing the attempt to force unwrap `tokenResponse`.