### PR TITLE
add support for 3ds2 messageVersion and sdk_version

### DIFF
--- a/ProcessOut/Classes/AuthorizationRequest.swift
+++ b/ProcessOut/Classes/AuthorizationRequest.swift
@@ -7,17 +7,21 @@
 
 class AuthorizationRequest: Codable {
     var source: String = ""
+    var sdkVersion: String = ""
     var incremental: Bool = false
     var threeDS2Enabled: Bool = true
     
     enum CodingKeys: String, CodingKey {
         case source = "source"
+        case clientVersion = "sdk_version"
         case incremental = "incremental"
         case threeDS2Enabled = "enable_three_d_s_2"
     }
     
-    init(source: String, incremental: Bool) {
+    init(source: String, incremental: Bool, sdkVersion: String) {
         self.source = source
         self.incremental = incremental
+        self.sdkVersion = sdkVersion
     }
+
 }

--- a/ProcessOut/Classes/AuthorizationRequest.swift
+++ b/ProcessOut/Classes/AuthorizationRequest.swift
@@ -7,21 +7,21 @@
 
 class AuthorizationRequest: Codable {
     var source: String = ""
-    var sdkVersion: String = ""
+    var thirdPartySDKVersion: String = ""
     var incremental: Bool = false
     var threeDS2Enabled: Bool = true
     
     enum CodingKeys: String, CodingKey {
         case source = "source"
-        case clientVersion = "sdk_version"
+        case thirdPartySDKVersion = "third_party_sdk_version"
         case incremental = "incremental"
         case threeDS2Enabled = "enable_three_d_s_2"
     }
     
-    init(source: String, incremental: Bool, sdkVersion: String) {
+    init(source: String, incremental: Bool, thirdPartySDKVersion: String) {
         self.source = source
         self.incremental = incremental
-        self.sdkVersion = sdkVersion
+        self.thirdPartySDKVersion = thirdPartySDKVersion
     }
 
 }

--- a/ProcessOut/Classes/DirectoryServerData.swift
+++ b/ProcessOut/Classes/DirectoryServerData.swift
@@ -10,10 +10,12 @@ public class DirectoryServerData: Codable {
     public var directoryServerID: String = ""
     public var directoryServerPublicKey: String = ""
     public var threeDSServerTransactionID: String = ""
+    public var messageVersion: String = ""
     
     private enum CodingKeys: String, CodingKey {
         case directoryServerID = "directoryServerID"
         case directoryServerPublicKey = "directoryServerPublicKey"
         case threeDSServerTransactionID = "threeDSServerTransID"
+        case messageVersion = "messageVersion"
     }
 }


### PR DESCRIPTION
## Description
The scheme and the issuer can decide of the protocol of the version during an authentication to offer more features, like exemptions, delegated authentication (rely on a 3rd party to do the authentication) or decoupled authentication (authentication that isn’t in the 3DS flow, eg offline).

When doing an authentication, the payment provider will indicate us on what version should we authenticate.
As of now, we force our merchants to use a static value of 2.1.

## Solution
Overload makeCardPayment method to accept and forward the SDKVersion and also modify the DirectoryServerData class to be able to unmarshal the messageVersion and access it.

## Notes
Version of tessel9 needs to be update, don't mind the go-mod changes, used custom version of t9 to test this. 
This change requires a few other changes in these repos:
Tessel9 -> [PR-1827](https://github.com/processout/tessel9/pull/1827)
API  -> [PR-1743](https://github.com/processout/api/pull/1743)
Android SDK -> [PR-31](https://github.com/processout/processout-android/pull/31)

## Jira Issue
[PROCESS0UT-657](https://checkout.atlassian.net/jira/software/projects/PROCESS0UT/boards/530?selectedIssue=PROCESS0UT-657)