### PR TITLE
Fix build warnings

### DIFF
--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -325,17 +325,13 @@ public class ProcessOut {
             return
         }
         
-        do {
-            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
-                handler.onError(error: ProcessOutException.InternalError)
-                return
-            }
-            makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
-                makeCardPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
-            })
-        } catch {
-            handler.onError(error: ProcessOutException.GenericError(error: error))
+        guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+            handler.onError(error: ProcessOutException.InternalError)
+            return
         }
+        makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
+            makeCardPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
+        })
     }
     
     /// Initiate an incremental payment authorization from a previously generated invoice and card token
@@ -352,17 +348,14 @@ public class ProcessOut {
             return
         }
         
-        do {
-            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
-                handler.onError(error: ProcessOutException.InternalError)
-                return
-            }
-            makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
-                makeIncrementalAuthorizationPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
-            })
-        } catch {
-            handler.onError(error: ProcessOutException.GenericError(error: error))
+        guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+            handler.onError(error: ProcessOutException.InternalError)
+            return
         }
+        makeAuthorizationRequest(invoiceId: invoiceId, json: json, handler: handler, with: with, actionHandlerCompletion: { (newSource) in
+            makeIncrementalAuthorizationPayment(invoiceId: invoiceId, token: newSource, handler: handler, with: with)
+        })
+        
     }
     
     /// Increments the authorization of an applicable invoice by a given amount
@@ -378,22 +371,19 @@ public class ProcessOut {
             return
         }
         
-        do {
-            guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
-                handler.onError(error: ProcessOutException.InternalError)
+        guard let json = try? JSONSerialization.jsonObject(with: body, options: []) as? [String : Any] else {
+            handler.onError(error: ProcessOutException.InternalError)
+            return
+        }
+        HttpRequest(route: "/invoices/" + invoiceId + "/increment_authorization", method: .post, parameters: json, completion: {(data, error) -> Void in
+            guard data != nil else {
+                handler.onError(error: error!)
                 return
             }
-            HttpRequest(route: "/invoices/" + invoiceId + "/increment_authorization", method: .post, parameters: json, completion: {(data, error) -> Void in
-                guard data != nil else {
-                    handler.onError(error: error!)
-                    return
-                }
-                
-                handler.onSuccess(invoiceId: invoiceId)
-            })
-        } catch {
-            handler.onError(error: .GenericError(error: error))
-        }
+            
+            handler.onSuccess(invoiceId: invoiceId)
+        })
+        
     }
     
     /// Create a customer token from a card ID

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -595,7 +595,7 @@ public class ProcessOut {
         ]
 
         // Remove any nil values from the array
-        let filteredPaginationParams = paginationParams.flatMap {$0}
+        let filteredPaginationParams = paginationParams.compactMap {$0}
 
         // Join the array into a single string separated by ampersands and return it
         return filteredPaginationParams.joined(separator: "&")


### PR DESCRIPTION
The aim of this PR is to fix four small build warnings that were raised by [`pod spec lint`](https://guides.cocoapods.org/terminal/commands.html#pod_spec_lint). Three of these warnings are caused by unreachable code in `catch` blocks where no error is thrown in the corresponding `do` block and the other is caused by the usage of a deprecated method, [`flatMap`](https://developer.apple.com/documentation/swift/sequence/2905332-flatmap). This PR addresses these issues by removing the extraneous `catch` blocks and replacing `flatMap` with [`compactMap`](https://developer.apple.com/documentation/swift/sequence/2950916-compactmap).