### PR TITLE
bugfix(POS-230): prevent fingerprint timeout handler to trigger when we have a successful fingerprint

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Alamofire (4.8.2)
-  - ProcessOut (2.15.0)
+  - ProcessOut (2.15.1)
 
 DEPENDENCIES:
   - Alamofire (~> 4.8.2)
@@ -16,8 +16,8 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: ae5c501addb7afdbb13687d7f2f722c78734c2d3
-  ProcessOut: ed5c3dcfd177a6b3f84a4ae8d587035d3d2885b1
+  ProcessOut: 8a691198ca721413504db87ac241c18e15b506c2
 
 PODFILE CHECKSUM: 06d3d269806a41b2f36a6489b9f2762f4c06d9b8
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ProcessOut.podspec
+++ b/ProcessOut.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'ProcessOut'
-  s.version          = '2.15.0'
+  s.version          = '2.15.1'
   s.summary          = 'The smart router for payments. Smartly route each transaction to the relevant payment providers.'
 
 # This description is used to generate tags and improve search results.

--- a/ProcessOut/Classes/FingerprintWebView.swift
+++ b/ProcessOut/Classes/FingerprintWebView.swift
@@ -8,30 +8,17 @@
 import Foundation
 
 class FingerprintWebView: ProcessOutWebView {
-    var timeOutHandler: DispatchWorkItem = DispatchWorkItem{}
+
+    private var timeOutTimer: Timer?
+    private let customerAction: CustomerAction
     
     public init(customerAction: CustomerAction, frame: CGRect, onResult: @escaping (String) -> Void, onAuthenticationError: @escaping () -> Void) {
+        self.customerAction = customerAction
         super.init(frame: frame, onResult: onResult, onAuthenticationError: onAuthenticationError)
         self.isHidden = false
-          
-        // Setup the fingerprint timeout handler
-        self.timeOutHandler = DispatchWorkItem {
-            if !self.timeOutHandler.isCancelled {
-                // Remove the webview
-                self.removeFromSuperview()
-
-                // Fallback to default fingerprint values
-                let fallback = self.generateFallbackFingerprintToken(URL: customerAction.value)
-                guard fallback.error == nil else {
-                    onAuthenticationError()
-                    return
-                }
-                onResult(fallback.fallbackToken!)
-            }
-        }
         
         // Start the timeout handler with a 10s timeout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 10.0, execute: timeOutHandler)
+        timeOutTimer = Timer.scheduledTimer(timeInterval: 10, target: self, selector: #selector(timeOutTimerDidFire), userInfo: nil, repeats: false)
     }
     
     required init?(coder: NSCoder) {
@@ -54,7 +41,20 @@ class FingerprintWebView: ProcessOutWebView {
         guard let parameters = url.queryParameters, let token = parameters["token"] else {
             return
         }
-        self.timeOutHandler.cancel()
+        timeOutTimer?.invalidate()
         onResult(token)
+    }
+    
+    @objc private func timeOutTimerDidFire() {
+        // Remove the webview
+        self.removeFromSuperview()
+
+        // Fallback to default fingerprint values
+        let fallback = self.generateFallbackFingerprintToken(URL: customerAction.value)
+        guard fallback.error == nil else {
+            onAuthenticationError()
+            return
+        }
+        onResult(fallback.fallbackToken!)
     }
 }

--- a/ProcessOut/Classes/ProcessOut.swift
+++ b/ProcessOut/Classes/ProcessOut.swift
@@ -76,7 +76,7 @@ public class ProcessOut {
         }
     }
 
-    static let ApiVersion: String = "v2.14.0"
+    static let ApiVersion: String = "v2.15.1"
     private static let ApiUrl: String = "https://api.processout.com"
     internal static let CheckoutUrl: String = "https://checkout.processout.com"
     internal static var ProjectId: String?


### PR DESCRIPTION
We noticed that when we are trying to do the fingerprint we launch a timeout of 10 seconds in case something goes wrong or the call get's delayed. For some reason even on a successful fingerprint, the DispatchQueue doesn't terminate and we keep ticking until the work finishes resulting in us picking up on the wrong result and processing it. 

Trying to rectify that by making sure and forcing the work to get canceled when we get a successful response back. 