### PR TITLE
fix(adhoc): version update bootstrap project

### DIFF
--- a/Scripts/UpdateVersion.sh
+++ b/Scripts/UpdateVersion.sh
@@ -50,6 +50,3 @@ EOF
 
 # Updates version in podspec
 sed -Ei "" "s|(s[.]version *= *)'(.*)'|\1'$VERSION'|" ProcessOut.podspec
-
-# Triggers project bootstrap to ensure that version is updated
-source Scripts/BootstrapProject.sh


### PR DESCRIPTION
## Description
Avoid triggering project bootstrap from version update script as its redundant. And same could be achieved by running this bootstrap script separately when needed (currently its never needed).

## Jira Issue
\-
