### PR TITLE
fix(adhoc): remove concurrency setting from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - 'master'
   workflow_call:
-concurrency:
-  group: ${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   run-tests:
     runs-on: macos-12


### PR DESCRIPTION
## Description
Removes concurrency setting from test workflow. Cancelling workflow on some branches may be unexpected and it was not working properly for non PR triggers.

## Jira Issue
\-
