### PR TITLE
fix(ad-hoc): release candidate workflow test trigger

### DIFF
--- a/.github/workflows/create_release_candidate.yml
+++ b/.github/workflows/create_release_candidate.yml
@@ -21,6 +21,7 @@ jobs:
           source Scripts/UpdateVersion.sh --${{ inputs.release_type }}
           echo "UPDATED_VERSION=$(cat Version.resolved)" >> $GITHUB_ENV
       - name: Create Pull Request
+        id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: |
@@ -33,6 +34,6 @@ jobs:
           title: 'feat(release): ${{ env.UPDATED_VERSION }}'
           assignees: ${{ github.actor }}
   run-tests:
-    uses: ./.github/workflows/test.yml
+    uses: ./.github/workflows/test.yml@${{ steps.cpr.outputs.pull-request-head-sha }}
     secrets: inherit
     needs: update-version

--- a/.github/workflows/create_release_candidate.yml
+++ b/.github/workflows/create_release_candidate.yml
@@ -14,8 +14,6 @@ on:
 jobs:
   update-version:
     runs-on: macos-12
-    outputs:
-      pull-request-head-sha: ${{ steps.cpr.outputs.pull-request-head-sha }}
     steps:
       - uses: actions/checkout@v3
       - name: Update Version
@@ -23,7 +21,6 @@ jobs:
           source Scripts/UpdateVersion.sh --${{ inputs.release_type }}
           echo "UPDATED_VERSION=$(cat Version.resolved)" >> $GITHUB_ENV
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@v5
         with:
           add-paths: |
@@ -35,9 +32,3 @@ jobs:
           delete-branch: true
           title: 'feat(release): ${{ env.UPDATED_VERSION }}'
           assignees: ${{ github.actor }}
-  run-tests:
-    uses: ./.github/workflows/test.yml
-    secrets: inherit
-    with:
-      reference: ${{ needs.update-version.outputs.pull-request-head-sha }}
-    needs: update-version

--- a/.github/workflows/create_release_candidate.yml
+++ b/.github/workflows/create_release_candidate.yml
@@ -14,6 +14,8 @@ on:
 jobs:
   update-version:
     runs-on: macos-12
+    outputs:
+      pull-request-head-sha: ${{ steps.cpr.outputs.pull-request-head-sha }}
     steps:
       - uses: actions/checkout@v3
       - name: Update Version
@@ -34,6 +36,8 @@ jobs:
           title: 'feat(release): ${{ env.UPDATED_VERSION }}'
           assignees: ${{ github.actor }}
   run-tests:
-    uses: ./.github/workflows/test.yml@${{ steps.cpr.outputs.pull-request-head-sha }}
+    uses: ./.github/workflows/test.yml
     secrets: inherit
+    with:
+      reference: ${{ needs.update-version.outputs.pull-request-head-sha }}
     needs: update-version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,6 @@ on:
       reference:
         required: false
         type: string
-concurrency:
-  group: ${{ github.head_ref }}
-  cancel-in-progress: true
 jobs:
   run-tests:
     runs-on: macos-12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - 'master'
   workflow_call:
+    inputs:
+      reference:
+        required: false
+        type: string
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
@@ -14,6 +18,8 @@ jobs:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.reference }}
       - name: Bootstrap Project
         uses: ./.github/actions/bootstrap-project
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,18 +5,12 @@ on:
   push:
     branches:
       - 'master'
-  workflow_call:
-    inputs:
-      reference:
-        required: false
-        type: string
+  workflow_dispatch:
 jobs:
   run-tests:
     runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.reference }}
       - name: Bootstrap Project
         uses: ./.github/actions/bootstrap-project
         with:


### PR DESCRIPTION
## Description
`workflow_call` is not reporting status so can't be used as a workaround. Instead `workflow_dispatch` is added 
to make it possible to manually trigger test run on any branch (including release candidate).

## Jira Issue
\-
