### PR TITLE
fix(POM-182): fix text field placeholder clipping

### DIFF
--- a/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Views/TextField/TextFieldContainerView.swift
+++ b/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Views/TextField/TextFieldContainerView.swift
@@ -82,13 +82,6 @@ final class TextFieldContainerView: UIView, InputFormTextField {
             return
         }
         UIView.perform(withAnimation: animated, duration: Constants.animationDuration) { [self] in
-            textField.attributedPlaceholder = AttributedStringBuilder()
-                .typography(style.placeholder.typography)
-                .textStyle(textStyle: .body)
-                .maximumFontSize(Constants.maximumFontSize)
-                .textColor(style.placeholder.color)
-                .string(textField.placeholder ?? "")
-                .build()
             let excludedTextAttributes: Set<NSAttributedString.Key> = [.paragraphStyle, .baselineOffset]
             let textAttributes = AttributedStringBuilder()
                 .typography(style.text.typography)
@@ -98,6 +91,14 @@ final class TextFieldContainerView: UIView, InputFormTextField {
                 .buildAttributes()
                 .filter { !excludedTextAttributes.contains($0.key) }
             textField.defaultTextAttributes = textAttributes
+            // `defaultTextAttributes` overwrites placeholder attributes so `attributedPlaceholder` must be set after.
+            textField.attributedPlaceholder = AttributedStringBuilder()
+                .typography(style.placeholder.typography)
+                .textStyle(textStyle: .body)
+                .maximumFontSize(Constants.maximumFontSize)
+                .textColor(style.placeholder.color)
+                .string(textField.placeholder ?? "")
+                .build()
             apply(style: style.border)
             apply(style: style.shadow)
             tintColor = style.tintColor


### PR DESCRIPTION
## Description
Placeholder is being clipped when font differs from font of typed text because `defaultTextAttributes` overwrite placeholder attributes. Issue is resolved by making placeholder configuration last in a chain.

<p float="left">
   <img src=https://user-images.githubusercontent.com/114918645/231495451-edd84d7d-116c-4e22-be4a-a2d8b70c880b.png width=300/>
   <img src=https://user-images.githubusercontent.com/114918645/231495465-3797e441-2b00-4b50-b624-38a373a0b5db.png width=300/>
</p>

## Jira Issue
https://checkout.atlassian.net/browse/POM-182
