### PR TITLE
fix(ad-hoc): use PO token in release workflow

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,5 +12,5 @@ jobs:
         uses: ./.github/actions/bootstrap-project
       - name: Create Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PO_GITHUB_TOKEN }}
         run: source Scripts/CreateRelease.sh


### PR DESCRIPTION
## Description
Ensures that child workflows will be triggered when release is published by CI.

## Jira Issue
\-
