### PR TITLE
fix(ad-hoc): markdown nested lists

### DIFF
--- a/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringBuilder.swift
+++ b/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringBuilder.swift
@@ -35,9 +35,6 @@ struct AttributedStringBuilder {
     /// Allows to alter font with the specified symbolic traits.
     var fontSymbolicTraits: UIFontDescriptor.SymbolicTraits = []
 
-    /// The text lists that contain text.
-    var textLists: [NSTextList] = []
-
     /// The text tab objects that represent the paragraph’s tab stops.
     var tabStops: [NSTextTab] = []
 
@@ -83,7 +80,6 @@ struct AttributedStringBuilder {
         paragraphStyle.paragraphSpacing = typography.paragraphSpacing
         paragraphStyle.alignment = alignment
         paragraphStyle.lineBreakMode = lineBreakMode
-        paragraphStyle.textLists = textLists
         paragraphStyle.tabStops = tabStops
         paragraphStyle.headIndent = headIndent
         attributes[.paragraphStyle] = paragraphStyle

--- a/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringMarkdownVisitor.swift
+++ b/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringMarkdownVisitor.swift
@@ -36,7 +36,6 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
     func visit(list: MarkdownList) -> NSAttributedString {
         var builder = self.builder
         let textList = textList(list)
-        builder.textLists.append(textList)
         builder.tabStops += listTabStops(textList, itemsCount: list.children.count)
         if let tabStop = builder.tabStops.last {
             builder.headIndent = tabStop.location

--- a/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringMarkdownVisitor.swift
+++ b/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringMarkdownVisitor.swift
@@ -39,7 +39,7 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
         builder.textLists.append(textList)
         builder.tabStops += listTabStops(textList, itemsCount: list.children.count)
         if let tabStop = builder.tabStops.last {
-            builder.headIndent += tabStop.location
+            builder.headIndent = tabStop.location
         }
         let itemsSeparator = NSAttributedString(string: Constants.paragraphSeparator)
         let attributedString = list.children


### PR DESCRIPTION
## Description
1. Markdown nested lists layout were broken because of wrong head indentation value.
<img src="https://github.com/processout/processout-ios/assets/114918645/7c28c408-8fae-4ab4-bb45-0e3c8dd2baec" width=300/>

2. iOS 16 handles NSAttributedString lists layout  automatically if set, but UI is not ideal. Solution was to opt-out and use the same logic as for earlier iOS versions.
<img src="https://github.com/processout/processout-ios/assets/114918645/f04a6999-08a2-4eaa-af16-9cd155014b92" width=300/>

## Solution
<p align="center">
  <img src="https://github.com/processout/processout-ios/assets/114918645/e7272da2-df08-45d3-8e85-c6e1017c5546" width=300/>
  <img src="https://github.com/processout/processout-ios/assets/114918645/888688bb-570f-46a3-a9e7-d27acd71a367" width=300/>
</p>

## Jira Issue
\-
