### PR TITLE
fix(POM-231): core layer thread safety

### DIFF
--- a/Sources/ProcessOut/Sources/Core/Cancellable/GroupCancellable.swift
+++ b/Sources/ProcessOut/Sources/Core/Cancellable/GroupCancellable.swift
@@ -16,10 +16,13 @@ final class GroupCancellable: POCancellable {
     }
 
     func add(_ cancellable: POCancellable) {
+        lock.lock()
         if isCancelled {
+            lock.unlock()
             cancellable.cancel()
         } else {
-            lock.withLock { cancellables.append(cancellable) }
+            cancellables.append(cancellable)
+            lock.unlock()
         }
     }
 

--- a/Sources/ProcessOut/Sources/Core/CodingUtils/VoidCodable.swift
+++ b/Sources/ProcessOut/Sources/Core/CodingUtils/VoidCodable.swift
@@ -5,6 +5,4 @@
 //  Created by Andrii Vysotskyi on 30.11.2022.
 //
 
-import Foundation
-
 struct VoidCodable: Codable { }

--- a/Sources/ProcessOut/Sources/Core/Markdown/MarkdownParser.swift
+++ b/Sources/ProcessOut/Sources/Core/Markdown/MarkdownParser.swift
@@ -8,9 +8,9 @@
 import Foundation
 @_implementationOnly import cmark
 
-final class MarkdownParser {
+enum MarkdownParser {
 
-    func parse(string: String) -> MarkdownDocument {
+    static func parse(string: String) -> MarkdownDocument {
         let document = string.withCString { pointer in
             cmark_parse_document(pointer, strlen(pointer), CMARK_OPT_SMART)
         }

--- a/Sources/ProcessOut/Sources/Core/Utils/POAutoAsync.swift
+++ b/Sources/ProcessOut/Sources/Core/Utils/POAutoAsync.swift
@@ -9,4 +9,4 @@
 /// automatically generate `async` methods for their callback-based counterparts. Only methods where last argument
 /// is a closure that matches `(Result<?, Error>) -> Void` type are picked, see `Templates/AutoAsync.stencil` in
 /// project's root directory for details.
-public protocol POAutoAsync {}
+@_marker public protocol POAutoAsync { }

--- a/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringBuilder.swift
+++ b/Sources/ProcessOut/Sources/UI/Shared/DesignSystem/Typography/AttributedStringBuilder.swift
@@ -48,7 +48,7 @@ struct AttributedStringBuilder {
         switch text {
         case .markdown(let markdown):
             let visitor = AttributedStringMarkdownVisitor(builder: self)
-            let document = MarkdownParser().parse(string: markdown)
+            let document = MarkdownParser.parse(string: markdown)
             return document.accept(visitor: visitor)
         case .plain(let string):
             return NSAttributedString(string: string, attributes: buildAttributes())


### PR DESCRIPTION
## Description
* Make `GroupCancellable` thread safe.
* Make `DefaultDeviceMetadataProvider` thread safe and ensure that is accesses `UIKit` only on main thread.

Additional improvements:
* Remove redundant `Foundation` import 
* Use `@_marker` for `POAutoAsync` to explicitly state that it is a marker protocol.

## Jira Issue
https://checkout.atlassian.net/browse/POM-231
