### PR TITLE
fix(POM-234): sdk configuration

### DIFF
--- a/Sources/ProcessOut/Sources/Core/Formatters/PhoneNumber/MetadataProvider/DefaultPhoneNumberMetadataProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/Formatters/PhoneNumber/MetadataProvider/DefaultPhoneNumberMetadataProvider.swift
@@ -11,36 +11,55 @@ final class DefaultPhoneNumberMetadataProvider: PhoneNumberMetadataProvider {
 
     static let shared = DefaultPhoneNumberMetadataProvider()
 
+    /// - NOTE: Method is asynchronous.
+    func prewarm() {
+        prewarm(sync: false)
+    }
+
     // MARK: - PhoneNumberMetadataProvider
 
     func metadata(for countryCode: String) -> PhoneNumberMetadata? {
         let transformedCountryCode = countryCode.applyingTransform(.toLatin, reverse: false) ?? countryCode
-        return metadata[transformedCountryCode]
-    }
-
-    func prewarm() {
-        _ = metadata
-    }
-
-    // MARK: - Private Methods
-
-    private init() {
-        // NOP
+        if let metadata = metadata {
+            return metadata[transformedCountryCode]
+        }
+        prewarm(sync: true)
+        return metadata?[transformedCountryCode]
     }
 
     // MARK: - Private Properties
 
-    private lazy var metadata: [String: PhoneNumberMetadata] = {
-        let metadata: [PhoneNumberMetadata]
-        do {
-            let data = try Data(contentsOf: Files.phoneNumberMetadata.url)
-            metadata = try JSONDecoder().decode([PhoneNumberMetadata].self, from: data)
-        } catch {
-            return [:]
+    private let dispatchQueue: DispatchQueue
+
+    @UnfairlyLocked
+    private var metadata: [String: PhoneNumberMetadata]?
+
+    // MARK: - Private Methods
+
+    private init() {
+        dispatchQueue = DispatchQueue(label: "process-out.phone-number-metadata-provider", qos: .userInitiated)
+    }
+
+    private func prewarm(sync: Bool) {
+        let dispatchWorkItem = DispatchWorkItem { [weak self] in
+            guard let self, self.metadata == nil else {
+                return
+            }
+            let groupedMetadata: [String: PhoneNumberMetadata]
+            do {
+                let data = try Data(contentsOf: Files.phoneNumberMetadata.url)
+                let metadata = try JSONDecoder().decode([PhoneNumberMetadata].self, from: data)
+                groupedMetadata = Dictionary(grouping: metadata, by: \.countryCode).compactMapValues { values in
+                    let countryCode = values.first!.countryCode // swiftlint:disable:this force_unwrapping
+                    return PhoneNumberMetadata(countryCode: countryCode, formats: values.flatMap(\.formats))
+                }
+            } catch {
+                assertionFailure("Failed to load metadata: \(error.localizedDescription)")
+                groupedMetadata = [:]
+            }
+            self.$metadata.withLock { $0 = groupedMetadata }
         }
-        return Dictionary(grouping: metadata, by: \.countryCode).compactMapValues { values in
-            let countryCode = values.first!.countryCode // swiftlint:disable:this force_unwrapping
-            return PhoneNumberMetadata(countryCode: countryCode, formats: values.flatMap(\.formats))
-        }
-    }()
+        let executor = sync ? dispatchQueue.sync : dispatchQueue.async
+        executor(dispatchWorkItem)
+    }
 }

--- a/Sources/ProcessOut/Sources/Core/Formatters/PhoneNumber/MetadataProvider/DefaultPhoneNumberMetadataProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/Formatters/PhoneNumber/MetadataProvider/DefaultPhoneNumberMetadataProvider.swift
@@ -13,7 +13,7 @@ final class DefaultPhoneNumberMetadataProvider: PhoneNumberMetadataProvider {
 
     /// - NOTE: Method is asynchronous.
     func prewarm() {
-        prewarm(sync: false)
+        loadMetadata(sync: false)
     }
 
     // MARK: - PhoneNumberMetadataProvider
@@ -23,7 +23,7 @@ final class DefaultPhoneNumberMetadataProvider: PhoneNumberMetadataProvider {
         if let metadata = metadata {
             return metadata[transformedCountryCode]
         }
-        prewarm(sync: true)
+        loadMetadata(sync: true)
         return metadata?[transformedCountryCode]
     }
 
@@ -40,7 +40,7 @@ final class DefaultPhoneNumberMetadataProvider: PhoneNumberMetadataProvider {
         dispatchQueue = DispatchQueue(label: "process-out.phone-number-metadata-provider", qos: .userInitiated)
     }
 
-    private func prewarm(sync: Bool) {
+    private func loadMetadata(sync: Bool) {
         let dispatchWorkItem = DispatchWorkItem { [weak self] in
             guard let self, self.metadata == nil else {
                 return

--- a/Sources/ProcessOut/Sources/Core/Logger/Destinations/SystemLoggerDestination.swift
+++ b/Sources/ProcessOut/Sources/Core/Logger/Destinations/SystemLoggerDestination.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-import os
+@_implementationOnly import os
 
 final class SystemLoggerDestination: LoggerDestination {
 

--- a/Sources/ProcessOut/Sources/Core/Utils/UnfairlyLocked.swift
+++ b/Sources/ProcessOut/Sources/Core/Utils/UnfairlyLocked.swift
@@ -1,0 +1,63 @@
+//
+//  UnfairlyLocked.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 14.07.2023.
+//
+
+@_implementationOnly import os
+
+/// A thread-safe wrapper around a value.
+@propertyWrapper
+final class UnfairlyLocked<Value> {
+
+    init(wrappedValue: Value) {
+        value = wrappedValue
+    }
+
+    /// The contained value. Unsafe for anything more than direct read or write.
+    var wrappedValue: Value {
+        lock.withLock { value }
+    }
+
+    var projectedValue: UnfairlyLocked<Value> {
+        self
+    }
+
+    func withLock<R>(_ body: (inout Value) -> R) -> R {
+        lock.withLock {
+            body(&value)
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private let lock = UnfairLock()
+    private var value: Value
+}
+
+/// An `os_unfair_lock` wrapper.
+private final class UnfairLock {
+
+    init() {
+        unfairLock = .allocate(capacity: 1)
+        unfairLock.initialize(to: os_unfair_lock())
+    }
+
+    func withLock<R>(_ body: () -> R) -> R {
+        defer {
+            os_unfair_lock_unlock(unfairLock)
+        }
+        os_unfair_lock_lock(unfairLock)
+        return body()
+    }
+
+    deinit {
+        unfairLock.deinitialize(count: 1)
+        unfairLock.deallocate()
+    }
+
+    // MARK: - Private Properties
+
+    private let unfairLock: os_unfair_lock_t
+}


### PR DESCRIPTION
## Description
We recommend to configure SDK when host application finishes launching. `DefaultPhoneNumberMetadataProvider` is being pre-warmed as part of the configuration but it may have negative impact on application launch time due to FS data reading. 

Solution is to make `prewarm` operation asynchronous, the only tricky part here is to ensure that data is loaded and available when requested for the first time. It is fine from user perspective since in most cases (if not all) because SDK won't require number formatting straight after configuration so loading will have enough time to complete.

## Jira Issue
https://checkout.atlassian.net/browse/POM-234
