### PR TITLE
fix(ad-hoc): avoid redundant native APM cell re-configuration

### DIFF
--- a/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/Cells/NativeAlternativePaymentMethodCell.swift
+++ b/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/Cells/NativeAlternativePaymentMethodCell.swift
@@ -9,6 +9,12 @@ import UIKit
 
 protocol NativeAlternativePaymentMethodCell: UICollectionViewCell {
 
+    /// Tells the cell that it is about to be displayed.
+    func willDisplay()
+
+    /// Tells the cell that it was removed from the collection view.
+    func didEndDisplaying()
+
     /// Should return input responder if any.
     var inputResponder: UIResponder? { get }
 

--- a/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/Cells/NativeAlternativePaymentMethodCodeInputCell.swift
+++ b/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/Cells/NativeAlternativePaymentMethodCodeInputCell.swift
@@ -24,11 +24,30 @@ final class NativeAlternativePaymentMethodCodeInputCell: UICollectionViewCell, N
         codeTextField.keyboardType = .numberPad
         codeTextField.textContentType = .oneTimeCode
         codeTextFieldCenterXConstraint.isActive = item.isCentered
-        observeChanges(item: item, style: style)
         self.item = item
+        self.style = style
     }
 
     // MARK: - NativeAlternativePaymentMethodCell
+
+    func willDisplay() {
+        guard let item, let style else {
+            return
+        }
+        let isInvalidObserver = item.value.$isInvalid.addObserver { [weak self] isInvalid in
+            self?.codeTextField.configure(isInvalid: isInvalid, style: style, animated: true)
+        }
+        let valueObserver = item.value.$text.addObserver { [weak self] updatedValue in
+            if self?.codeTextField.text != updatedValue {
+                self?.codeTextField.text = item.value.text
+            }
+        }
+        self.observations = [isInvalidObserver, valueObserver]
+    }
+
+    func didEndDisplaying() {
+        observations = []
+    }
 
     var inputResponder: UIResponder? {
         codeTextField
@@ -50,6 +69,7 @@ final class NativeAlternativePaymentMethodCodeInputCell: UICollectionViewCell, N
     // swiftlint:enable implicitly_unwrapped_optional
 
     private var item: NativeAlternativePaymentMethodViewModelState.CodeInputItem?
+    private var style: POInputStyle?
     private var observations: [AnyObject] = []
 
     // MARK: - Private Methods
@@ -78,18 +98,6 @@ final class NativeAlternativePaymentMethodCodeInputCell: UICollectionViewCell, N
     @objc
     private func textFieldEditingChanged() {
         item?.value.text = codeTextField.text ?? ""
-    }
-
-    private func observeChanges(item: NativeAlternativePaymentMethodViewModelState.CodeInputItem, style: POInputStyle) {
-        let isInvalidObserver = item.value.$isInvalid.addObserver { [weak self] isInvalid in
-            self?.codeTextField.configure(isInvalid: isInvalid, style: style, animated: true)
-        }
-        let valueObserver = item.value.$text.addObserver { [weak self] updatedValue in
-            if self?.codeTextField.text != updatedValue {
-                self?.codeTextField.text = item.value.text
-            }
-        }
-        self.observations = [isInvalidObserver, valueObserver]
     }
 }
 

--- a/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/NativeAlternativePaymentMethodViewController.swift
+++ b/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/View/NativeAlternativePaymentMethodViewController.swift
@@ -104,6 +104,18 @@ final class NativeAlternativePaymentMethodViewController<ViewModel: NativeAltern
         }
     }
 
+    func collectionView(_: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let cell = cell as? NativeAlternativePaymentMethodCell
+        cell?.willDisplay()
+    }
+
+    func collectionView(
+        _: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath
+    ) {
+        let cell = cell as? NativeAlternativePaymentMethodCell
+        cell?.didEndDisplaying()
+    }
+
     // MARK: - UICollectionViewDelegateFlowLayout
 
     func collectionView(


### PR DESCRIPTION
## Description
Collection view may dequeue another hidden cell and keep it in hierarchy for some reason (see [this](https://stackoverflow.com/questions/48926506/uicollectionview-dequeues-hidden-cells-when-paging-is-enabled) for similar problem). So to ensure that only visible cells are responding to item changes, subscription code is moved to `willDisplayCell` collection delegate's method.

## Jira Issue
\-
