### PR TITLE
fix(POM-235): project bootstrap

### DIFF
--- a/.github/actions/bootstrap-project/action.yml
+++ b/.github/actions/bootstrap-project/action.yml
@@ -12,13 +12,6 @@ runs:
       with:
         ruby-version: '3.1.2'
         bundler-cache: true
-    - name: Cache Mint Packages
-      uses: actions/cache@v3
-      with:
-        path: ~/.mint/packages
-        key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-        restore-keys: |
-          ${{ runner.os }}-mint-
     - name: Write Constants
       run: |
         CONSTANTS=$'${{ inputs.test-project-constants }}'
@@ -30,5 +23,5 @@ runs:
       shell: bash
     # - name: Bootstrap Example Project
     #   if: ${{ inputs.test-project-constants != '' }}
-    #   run: cd Example && ./Scripts/BootstrapProject.sh --skip-mint-bootstrap
+    #   run: cd Example && ./Scripts/BootstrapProject.sh
     #   shell: bash

--- a/Brewfile
+++ b/Brewfile
@@ -1,1 +1,4 @@
-brew "mint"
+brew "xcodegen"
+brew "swiftlint"
+brew "swiftgen"
+brew "sourcery"

--- a/Example/Brewfile
+++ b/Example/Brewfile
@@ -1,1 +1,3 @@
-../Brewfile
+brew "xcodegen"
+brew "swiftlint"
+brew "swiftgen"

--- a/Example/Mintfile
+++ b/Example/Mintfile
@@ -1,1 +1,0 @@
-../Mintfile

--- a/Example/Scripts/BootstrapProject.sh
+++ b/Example/Scripts/BootstrapProject.sh
@@ -5,13 +5,8 @@ set -euo pipefail
 # Installs brew dependencies
 brew bundle -q
 
-# Installs mint dependencies if needed
-if ! [[ "$@" =~ '--skip-mint-bootstrap' ]]; then
-    mint bootstrap
-fi
-
 # Generates project
-mint run xcodegen generate
+xcodegen generate
 
 # Creates hardlink to Package.resolved
 SWIFTPM_DIR='Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm'

--- a/Example/Scripts/Lint.sh
+++ b/Example/Scripts/Lint.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-mint run swiftlint lint --strict
+# Add brew binaries to PATH
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Lint
+swiftlint lint --strict

--- a/Example/Scripts/SwiftGen/SwiftGen.sh
+++ b/Example/Scripts/SwiftGen/SwiftGen.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-mint run swiftgen config run
+# Add brew binaries to PATH
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Run SwiftGen
+swiftgen config run

--- a/Example/swiftgen.yml
+++ b/Example/swiftgen.yml
@@ -8,7 +8,7 @@ xcassets:
     - Images.xcassets
     - Colors.xcassets
   outputs:
-    - templateName: swift5
+    - templatePath: ${SRCROOT}/../Templates/xcassets.stencil
       params:
         forceFileNameEnum: true
         forceProvidesNamespaces: true

--- a/Mintfile
+++ b/Mintfile
@@ -1,4 +1,0 @@
-yonaskolb/xcodegen@2.35.0
-realm/SwiftLint@0.52.3
-SwiftGen/SwiftGen@6.5.1
-krzysztofzablocki/Sourcery@2.0.2

--- a/Scripts/BootstrapProject.sh
+++ b/Scripts/BootstrapProject.sh
@@ -8,13 +8,10 @@ export CURRENT_VERSION="$(cat Version.resolved)"
 # Installs brew dependencies
 brew bundle -q
 
-# Installs mint dependencies
-mint bootstrap
-
 # Installs bundler dependencies if needed
 if ! [[ "$@" =~ '--skip-bundle-instal' ]]; then
     bundle check || bundle install
 fi
 
 # Creates project
-mint run xcodegen generate
+xcodegen generate

--- a/Scripts/CMark/CreateXcframework.sh
+++ b/Scripts/CMark/CreateXcframework.sh
@@ -36,7 +36,7 @@ cp "$SCRIPT_DIR/module.modulemap" src/
 cp "$SCRIPT_DIR/project.yml" .
 
 # Generate project
-mint run xcodegen generate
+xcodegen generate
 
 # Create frameworks for needed platforms
 xcodebuild archive -scheme cmark -destination "generic/platform=iOS" -archivePath ./cmark-iOS

--- a/Scripts/Lint.sh
+++ b/Scripts/Lint.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-mint run swiftlint lint --strict
+# Add brew binaries to PATH
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Lint
+swiftlint lint --strict

--- a/Scripts/Sourcery.sh
+++ b/Scripts/Sourcery.sh
@@ -2,8 +2,12 @@
 
 set -euo pipefail
 
-mint run sourcery \
+# Add brew binaries to PATH
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Run sourcery
+sourcery \
   --sources $PROJECT_DIR/Sources/$TARGET_NAME/Sources \
-  --templates $PROJECT_DIR/Templates \
+  --templates $PROJECT_DIR/Templates/AutoAsync.stencil \
   --parseDocumentation \
   --output $PROJECT_DIR/Sources/$TARGET_NAME/Sources/Generated/Sourcery+Generated.swift

--- a/Scripts/SwiftGen.sh
+++ b/Scripts/SwiftGen.sh
@@ -2,4 +2,8 @@
 
 set -euo pipefail
 
-mint run swiftgen config run --config "${TARGET_ROOT}/swiftgen.yml"
+# Add brew binaries to PATH
+export PATH="/opt/homebrew/bin:$PATH"
+
+# Run SwiftGen
+swiftgen config run --config "${TARGET_ROOT}/swiftgen.yml"

--- a/Sources/ProcessOut/Sources/Core/Extensions/Strings+Localized.swift
+++ b/Sources/ProcessOut/Sources/Core/Extensions/Strings+Localized.swift
@@ -22,7 +22,7 @@ extension Strings {
     ///
     /// The implementation falls back to the framework's bundle in case the main application doesn't
     /// provide translations for missing languages to ensure that we don't display untranslated strings.
-    static func localized(_ key: String, _ table: String) -> String {
+    static func localized(_ key: String, _ table: String, _: String) -> String {
         if Bundle.main.preferredLocalizations.first == BundleLocator.bundle.preferredLocalizations.first {
             return BundleLocator.bundle.localizedString(forKey: key, value: nil, table: table)
         }

--- a/Sources/ProcessOut/Sources/Generated/Assets+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Assets+Generated.swift
@@ -9,12 +9,6 @@
   import UIKit
 #endif
 
-// Deprecated typealiases
-@available(*, deprecated, renamed: "ColorAsset.Color", message: "This typealias will be removed in SwiftGen 7.0")
-internal typealias AssetColorTypeAlias = ColorAsset.Color
-@available(*, deprecated, renamed: "ImageAsset.Image", message: "This typealias will be removed in SwiftGen 7.0")
-internal typealias AssetImageTypeAlias = ImageAsset.Image
-
 // swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Asset Catalogs
@@ -154,20 +148,4 @@ internal struct ImageAsset {
     return result
   }
   #endif
-}
-
-internal extension ImageAsset.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
-  @available(macOS, deprecated,
-    message: "This initializer is unsafe on macOS, please use the ImageAsset.image property")
-  convenience init?(asset: ImageAsset) {
-    #if os(iOS) || os(tvOS)
-    let bundle = BundleLocator.bundle
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(macOS)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
 }

--- a/Sources/ProcessOut/Sources/Generated/Fonts+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Fonts+Generated.swift
@@ -6,13 +6,15 @@
 #elseif os(iOS) || os(tvOS) || os(watchOS)
   import UIKit.UIFont
 #endif
+#if canImport(SwiftUI)
+  import SwiftUI
+#endif
 
 // Deprecated typealiases
 @available(*, deprecated, renamed: "FontConvertible.Font", message: "This typealias will be removed in SwiftGen 7.0")
 internal typealias Font = FontConvertible.Font
 
-// swiftlint:disable superfluous_disable_command
-// swiftlint:disable file_length
+// swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Fonts
 
@@ -66,10 +68,39 @@ internal struct FontConvertible {
     return font
   }
 
+  #if canImport(SwiftUI)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+  internal func swiftUIFont(size: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(fixedSize: CGFloat) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, fixedSize: fixedSize)
+  }
+
+  @available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+  internal func swiftUIFont(size: CGFloat, relativeTo textStyle: SwiftUI.Font.TextStyle) -> SwiftUI.Font {
+    return SwiftUI.Font.custom(self, size: size, relativeTo: textStyle)
+  }
+  #endif
+
   internal func register() {
     // swiftlint:disable:next conditional_returns_on_newline
     guard let url = url else { return }
     CTFontManagerRegisterFontsForURL(url as CFURL, .process, nil)
+  }
+
+  fileprivate func registerIfNeeded() {
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    if !UIFont.fontNames(forFamilyName: family).contains(name) {
+      register()
+    }
+    #elseif os(macOS)
+    if let url = url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
+      register()
+    }
+    #endif
   }
 
   fileprivate var url: URL? {
@@ -80,16 +111,34 @@ internal struct FontConvertible {
 
 internal extension FontConvertible.Font {
   convenience init?(font: FontConvertible, size: CGFloat) {
-    #if os(iOS) || os(tvOS) || os(watchOS)
-    if !UIFont.fontNames(forFamilyName: font.family).contains(font.name) {
-      font.register()
-    }
-    #elseif os(macOS)
-    if let url = font.url, CTFontManagerGetScopeForURL(url as CFURL) == .none {
-      font.register()
-    }
-    #endif
-
+    font.registerIfNeeded()
     self.init(name: font.name, size: size)
   }
 }
+
+#if canImport(SwiftUI)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, macOS 10.15, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, size: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size)
+  }
+}
+
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
+internal extension SwiftUI.Font {
+  static func custom(_ font: FontConvertible, fixedSize: CGFloat) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, fixedSize: fixedSize)
+  }
+
+  static func custom(
+    _ font: FontConvertible,
+    size: CGFloat,
+    relativeTo textStyle: SwiftUI.Font.TextStyle
+  ) -> SwiftUI.Font {
+    font.registerIfNeeded()
+    return custom(font.name, size: size, relativeTo: textStyle)
+  }
+}
+#endif

--- a/Sources/ProcessOut/Sources/Generated/Strings+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Strings+Generated.swift
@@ -3,101 +3,101 @@
 
 import Foundation
 
-// swiftlint:disable superfluous_disable_command file_length implicit_return
+// swiftlint:disable superfluous_disable_command file_length implicit_return prefer_self_in_static_references
 
 // MARK: - Strings
 
 // swiftlint:disable explicit_type_interface function_parameter_count identifier_name line_length
 // swiftlint:disable nesting type_body_length type_name vertical_whitespace_opening_braces
 internal enum Strings {
-
   internal enum CardTokenization {
     /// Add New Card
-    internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.title") }
+    internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.title", fallback: "Add New Card") }
     internal enum CancelButton {
       /// Cancel
-      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.cancel-button.title") }
+      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.cancel-button.title", fallback: "Cancel") }
     }
     internal enum CardDetails {
       /// Card Information
-      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.title") }
+      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.title", fallback: "Card Information") }
       internal enum Cvc {
         /// Cardholder Name
-        internal static var cardholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.cvc.cardholder") }
+        internal static var cardholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.cvc.cardholder", fallback: "Cardholder Name") }
         /// CVC
-        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.cvc.placeholder") }
+        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.cvc.placeholder", fallback: "CVC") }
       }
       internal enum Expiration {
         /// MM / YY
-        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.expiration.placeholder") }
+        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.expiration.placeholder", fallback: "MM / YY") }
       }
       internal enum Number {
         /// 4242 4242 4242 4242
-        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.number.placeholder") }
+        internal static var placeholder: String { return Strings.tr("ProcessOut", "card-tokenization.card-details.number.placeholder", fallback: "4242 4242 4242 4242") }
       }
     }
     internal enum SubmitButton {
       /// Submit
-      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.submit-button.title") }
+      internal static var title: String { return Strings.tr("ProcessOut", "card-tokenization.submit-button.title", fallback: "Submit") }
     }
   }
-
   internal enum NativeAlternativePayment {
-    /// Pay with %@
+    /// ProcessOut.strings
+    ///   
+    /// 
+    ///   Created by Andrii Vysotskyi on 07.10.2022.
     internal static func title(_ p1: Any) -> String {
-      return Strings.tr("ProcessOut", "native-alternative-payment.title", String(describing: p1))
+      return Strings.tr("ProcessOut", "native-alternative-payment.title", String(describing: p1), fallback: "Pay with %@")
     }
     internal enum CancelButton {
       /// Cancel
-      internal static var title: String { return Strings.tr("ProcessOut", "native-alternative-payment.cancel-button.title") }
+      internal static var title: String { return Strings.tr("ProcessOut", "native-alternative-payment.cancel-button.title", fallback: "Cancel") }
     }
     internal enum Email {
       /// name@example.com
-      internal static var placeholder: String { return Strings.tr("ProcessOut", "native-alternative-payment.email.placeholder") }
+      internal static var placeholder: String { return Strings.tr("ProcessOut", "native-alternative-payment.email.placeholder", fallback: "name@example.com") }
     }
     internal enum Error {
       /// Email is not valid
-      internal static var invalidEmail: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-email") }
+      internal static var invalidEmail: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-email", fallback: "Email is not valid") }
       /// Plural format key: "%#@length@"
       internal static func invalidLength(_ p1: Int) -> String {
-        return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-length", p1)
+        return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-length", p1, fallback: "Plural format key: \"%#@length@\"")
       }
       /// Number is not valid
-      internal static var invalidNumber: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-number") }
+      internal static var invalidNumber: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-number", fallback: "Number is not valid") }
       /// Phone number is not valid
-      internal static var invalidPhone: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-phone") }
+      internal static var invalidPhone: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-phone", fallback: "Phone number is not valid") }
       /// Value is not valid
-      internal static var invalidValue: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-value") }
+      internal static var invalidValue: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.invalid-value", fallback: "Value is not valid") }
       /// Parameter is required
-      internal static var requiredParameter: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.required-parameter") }
+      internal static var requiredParameter: String { return Strings.tr("ProcessOut", "native-alternative-payment.error.required-parameter", fallback: "Parameter is required") }
     }
     internal enum Phone {
       /// Enter phone number
-      internal static var placeholder: String { return Strings.tr("ProcessOut", "native-alternative-payment.phone.placeholder") }
+      internal static var placeholder: String { return Strings.tr("ProcessOut", "native-alternative-payment.phone.placeholder", fallback: "Enter phone number") }
     }
     internal enum SubmitButton {
       /// Pay
-      internal static var defaultTitle: String { return Strings.tr("ProcessOut", "native-alternative-payment.submit-button.default-title") }
+      internal static var defaultTitle: String { return Strings.tr("ProcessOut", "native-alternative-payment.submit-button.default-title", fallback: "Pay") }
       /// Pay %@
       internal static func title(_ p1: Any) -> String {
-        return Strings.tr("ProcessOut", "native-alternative-payment.submit-button.title", String(describing: p1))
+        return Strings.tr("ProcessOut", "native-alternative-payment.submit-button.title", String(describing: p1), fallback: "Pay %@")
       }
     }
     internal enum Success {
       /// Success!
       /// Payment approved
-      internal static var message: String { return Strings.tr("ProcessOut", "native-alternative-payment.success.message") }
+      internal static var message: String { return Strings.tr("ProcessOut", "native-alternative-payment.success.message", fallback: "Success!\nPayment approved") }
     }
   }
-
   internal enum Test3DS {
     internal enum Challenge {
       /// Accept
-      internal static var accept: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.accept") }
+      internal static var accept: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.accept", fallback: "Accept") }
       /// Reject
-      internal static var reject: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.reject") }
+      internal static var reject: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.reject", fallback: "Reject") }
       /// Do you want to accept the 3DS2 challenge?
-      internal static var title: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.title") }
+      internal static var title: String { return Strings.tr("ProcessOut", "test-3-d-s.challenge.title", fallback: "Do you want to accept the 3DS2 challenge?") }
     }
   }
 }
@@ -107,8 +107,8 @@ internal enum Strings {
 // MARK: - Implementation Details
 
 extension Strings {
-  private static func tr(_ table: String, _ key: String, _ args: CVarArg...) -> String {
-    let format = Strings.localized(key, table)
+  private static func tr(_ table: String, _ key: String, _ args: CVarArg..., fallback value: String) -> String {
+    let format = Strings.localized(key, table, value)
     return String(format: format, locale: Locale.current, arguments: args)
   }
 }

--- a/Sources/ProcessOut/swiftgen.yml
+++ b/Sources/ProcessOut/swiftgen.yml
@@ -7,7 +7,7 @@ xcassets:
     - Images.xcassets
     - Colors.xcassets
   outputs:
-    - templateName: swift5
+    - templatePath: ${SRCROOT}/Templates/xcassets.stencil
       params:
         forceFileNameEnum: true
         forceProvidesNamespaces: true

--- a/Templates/xcassets.stencil
+++ b/Templates/xcassets.stencil
@@ -1,0 +1,363 @@
+// swiftlint:disable all
+// Generated using SwiftGen — https://github.com/SwiftGen/SwiftGen
+
+{% if catalogs %}
+{% macro hasValuesBlock assets filter %}
+  {%- for asset in assets -%}
+    {%- if asset.type == filter -%}
+      1
+    {%- elif asset.items -%}
+      {% call hasValuesBlock asset.items filter %}
+    {%- endif -%}
+  {%- endfor -%}
+{% endmacro %}
+{% set enumName %}{{param.enumName|default:"Asset"}}{% endset %}
+{% set arResourceGroupType %}{{param.arResourceGroupTypeName|default:"ARResourceGroupAsset"}}{% endset %}
+{% set colorType %}{{param.colorTypeName|default:"ColorAsset"}}{% endset %}
+{% set dataType %}{{param.dataTypeName|default:"DataAsset"}}{% endset %}
+{% set imageType %}{{param.imageTypeName|default:"ImageAsset"}}{% endset %}
+{% set symbolType %}{{param.symbolTypeName|default:"SymbolAsset"}}{% endset %}
+{% set forceNamespaces %}{{param.forceProvidesNamespaces|default:"false"}}{% endset %}
+{% set accessModifier %}{% if param.publicAccess %}public{% else %}internal{% endif %}{% endset %}
+{% set hasARResourceGroup %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "arresourcegroup" %}{% endfor %}{% endset %}
+{% set hasColor %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "color" %}{% endfor %}{% endset %}
+{% set hasData %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "data" %}{% endfor %}{% endset %}
+{% set hasImage %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "image" %}{% endfor %}{% endset %}
+{% set hasSymbol %}{% for catalog in catalogs %}{% call hasValuesBlock catalog.assets "symbol" %}{% endfor %}{% endset %}
+#if os(macOS)
+  import AppKit
+#elseif os(iOS)
+{% if hasARResourceGroup %}
+  import ARKit
+{% endif %}
+  import UIKit
+#elseif os(tvOS) || os(watchOS)
+  import UIKit
+#endif
+
+// Deprecated typealiases
+{% if hasColor %}
+@available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
+{% endif %}
+{% if hasImage %}
+@available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
+{{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
+{% endif %}
+
+// swiftlint:disable superfluous_disable_command file_length implicit_return
+
+// MARK: - Asset Catalogs
+
+{% macro enumBlock assets %}
+  {% call casesBlock assets %}
+  {% if param.allValues %}
+
+  // swiftlint:disable trailing_comma
+  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allColors: [{{colorType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allImages: [{{imageType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
+  {% if hasItems %}
+  @available(*, deprecated, message: "All values properties are now deprecated")
+  {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
+    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
+  ]
+  {% endif %}
+  // swiftlint:enable trailing_comma
+  {% endif %}
+{% endmacro %}
+{% macro casesBlock assets %}
+  {% for asset in assets %}
+  {% if asset.type == "arresourcegroup" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{arResourceGroupType}}(name: "{{asset.value}}")
+  {% elif asset.type == "color" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{colorType}}(name: "{{asset.value}}")
+  {% elif asset.type == "data" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{dataType}}(name: "{{asset.value}}")
+  {% elif asset.type == "image" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{imageType}}(name: "{{asset.value}}")
+  {% elif asset.type == "symbol" %}
+  {{accessModifier}} static let {{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}} = {{symbolType}}(name: "{{asset.value}}")
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {{accessModifier}} enum {{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% filter indent:2," ",true %}{% call casesBlock asset.items %}{% endfilter %}
+  }
+  {% elif asset.items %}
+  {% call casesBlock asset.items %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+{% macro allValuesBlock assets filter prefix %}
+  {% for asset in assets %}
+  {% if asset.type == filter %}
+  {{prefix}}{{asset.name|swiftIdentifier:"pretty"|lowerFirstWord|escapeReservedKeywords}},
+  {% elif asset.items and ( forceNamespaces == "true" or asset.isNamespaced == "true" ) %}
+  {% set prefix2 %}{{prefix}}{{asset.name|swiftIdentifier:"pretty"|escapeReservedKeywords}}.{% endset %}
+  {% call allValuesBlock asset.items filter prefix2 %}
+  {% elif asset.items %}
+  {% call allValuesBlock asset.items filter prefix %}
+  {% endif %}
+  {% endfor %}
+{% endmacro %}
+// swiftlint:disable identifier_name line_length nesting type_body_length type_name
+{{accessModifier}} enum {{enumName}} {
+  {% if catalogs.count > 1 or param.forceFileNameEnum %}
+  {% for catalog in catalogs %}
+  {{accessModifier}} enum {{catalog.name|swiftIdentifier:"pretty"|escapeReservedKeywords}} {
+    {% if catalog.assets %}
+    {% filter indent:2," ",true %}{% call enumBlock catalog.assets %}{% endfilter %}
+    {% endif %}
+  }
+  {% endfor %}
+  {% else %}
+  {% call enumBlock catalogs.first.assets %}
+  {% endif %}
+}
+// swiftlint:enable identifier_name line_length nesting type_body_length type_name
+
+// MARK: - Implementation Details
+{% if hasARResourceGroup %}
+
+{{accessModifier}} struct {{arResourceGroupType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS)
+  @available(iOS 11.3, *)
+  {{accessModifier}} var referenceImages: Set<ARReferenceImage> {
+    return ARReferenceImage.referenceImages(in: self)
+  }
+
+  @available(iOS 12.0, *)
+  {{accessModifier}} var referenceObjects: Set<ARReferenceObject> {
+    return ARReferenceObject.referenceObjects(in: self)
+  }
+  #endif
+}
+
+#if os(iOS)
+@available(iOS 11.3, *)
+{{accessModifier}} extension ARReferenceImage {
+  static func referenceImages(in asset: {{arResourceGroupType}}) -> Set<ARReferenceImage> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceImages(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+
+@available(iOS 12.0, *)
+{{accessModifier}} extension ARReferenceObject {
+  static func referenceObjects(in asset: {{arResourceGroupType}}) -> Set<ARReferenceObject> {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    return referenceObjects(inGroupNamed: asset.name, bundle: bundle) ?? Set()
+  }
+}
+#endif
+{% endif %}
+{% if hasColor %}
+
+{{accessModifier}} final class {{colorType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Color = NSColor
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Color = UIColor
+  #endif
+
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  {{accessModifier}} private(set) lazy var color: Color = {
+    guard let color = Color(asset: self) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }()
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 11.0, tvOS 11.0, *)
+  {{accessModifier}} func color(compatibleWith traitCollection: UITraitCollection) -> Color {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let color = Color(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load color asset named \(name).")
+    }
+    return color
+  }
+  #endif
+
+  fileprivate init(name: String) {
+    self.name = name
+  }
+}
+
+{{accessModifier}} extension {{colorType}}.Color {
+  @available(iOS 11.0, tvOS 11.0, watchOS 4.0, macOS 10.13, *)
+  convenience init?(asset: {{colorType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSColor.Name(asset.name), bundle: bundle)
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+{% endif %}
+{% if hasData %}
+
+{{accessModifier}} struct {{dataType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  @available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+  {{accessModifier}} var data: NSDataAsset {
+    guard let data = NSDataAsset(asset: self) else {
+      fatalError("Unable to load data asset named \(name).")
+    }
+    return data
+  }
+}
+
+@available(iOS 9.0, tvOS 9.0, watchOS 6.0, macOS 10.11, *)
+{{accessModifier}} extension NSDataAsset {
+  convenience init?(asset: {{dataType}}) {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS) || os(watchOS)
+    self.init(name: asset.name, bundle: bundle)
+    #elseif os(macOS)
+    self.init(name: NSDataAsset.Name(asset.name), bundle: bundle)
+    #endif
+  }
+}
+{% endif %}
+{% if hasImage %}
+
+{{accessModifier}} struct {{imageType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(macOS)
+  {{accessModifier}} typealias Image = NSImage
+  #elseif os(iOS) || os(tvOS) || os(watchOS)
+  {{accessModifier}} typealias Image = UIImage
+  #endif
+
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, macOS 10.7, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    let name = NSImage.Name(self.name)
+    let image = (bundle == .main) ? NSImage(named: name) : bundle.image(forResource: name)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+
+  #if os(iOS) || os(tvOS)
+  @available(iOS 8.0, tvOS 9.0, *)
+  {{accessModifier}} func image(compatibleWith traitCollection: UITraitCollection) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, compatibleWith: traitCollection) else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return result
+  }
+  #endif
+}
+
+{{accessModifier}} extension {{imageType}}.Image {
+  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
+  @available(macOS, deprecated,
+    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
+  convenience init?(asset: {{imageType}}) {
+    #if os(iOS) || os(tvOS)
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    self.init(named: asset.name, in: bundle, compatibleWith: nil)
+    #elseif os(macOS)
+    self.init(named: NSImage.Name(asset.name))
+    #elseif os(watchOS)
+    self.init(named: asset.name)
+    #endif
+  }
+}
+{% endif %}
+{% if hasSymbol %}
+
+{{accessModifier}} struct {{symbolType}} {
+  {{accessModifier}} fileprivate(set) var name: String
+
+  #if os(iOS) || os(tvOS) || os(watchOS)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} typealias Configuration = UIImage.SymbolConfiguration
+  {{accessModifier}} typealias Image = UIImage
+
+  @available(iOS 12.0, tvOS 12.0, watchOS 5.0, *)
+  {{accessModifier}} var image: Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    #if os(iOS) || os(tvOS)
+    let image = Image(named: name, in: bundle, compatibleWith: nil)
+    #elseif os(watchOS)
+    let image = Image(named: name)
+    #endif
+    guard let result = image else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+  {{accessModifier}} func image(with configuration: Configuration) -> Image {
+    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
+    guard let result = Image(named: name, in: bundle, with: configuration) else {
+      fatalError("Unable to load symbol asset named \(name).")
+    }
+    return result
+  }
+  #endif
+}
+{% endif %}
+{% if not param.bundle %}
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type
+{% endif %}
+{% else %}
+// No assets found
+{% endif %}

--- a/Templates/xcassets.stencil
+++ b/Templates/xcassets.stencil
@@ -35,62 +35,12 @@
   import UIKit
 #endif
 
-// Deprecated typealiases
-{% if hasColor %}
-@available(*, deprecated, renamed: "{{colorType}}.Color", message: "This typealias will be removed in SwiftGen 7.0")
-{{accessModifier}} typealias {{param.colorAliasName|default:"AssetColorTypeAlias"}} = {{colorType}}.Color
-{% endif %}
-{% if hasImage %}
-@available(*, deprecated, renamed: "{{imageType}}.Image", message: "This typealias will be removed in SwiftGen 7.0")
-{{accessModifier}} typealias {{param.imageAliasName|default:"AssetImageTypeAlias"}} = {{imageType}}.Image
-{% endif %}
-
 // swiftlint:disable superfluous_disable_command file_length implicit_return
 
 // MARK: - Asset Catalogs
 
 {% macro enumBlock assets %}
   {% call casesBlock assets %}
-  {% if param.allValues %}
-
-  // swiftlint:disable trailing_comma
-  {% set hasItems %}{% call hasValuesBlock assets "arresourcegroup" %}{% endset %}
-  {% if hasItems %}
-  @available(*, deprecated, message: "All values properties are now deprecated")
-  {{accessModifier}} static let allResourceGroups: [{{arResourceGroupType}}] = [
-    {% filter indent:2," ",true %}{% call allValuesBlock assets "arresourcegroup" "" %}{% endfilter %}
-  ]
-  {% endif %}
-  {% set hasItems %}{% call hasValuesBlock assets "color" %}{% endset %}
-  {% if hasItems %}
-  @available(*, deprecated, message: "All values properties are now deprecated")
-  {{accessModifier}} static let allColors: [{{colorType}}] = [
-    {% filter indent:2," ",true %}{% call allValuesBlock assets "color" "" %}{% endfilter %}
-  ]
-  {% endif %}
-  {% set hasItems %}{% call hasValuesBlock assets "data" %}{% endset %}
-  {% if hasItems %}
-  @available(*, deprecated, message: "All values properties are now deprecated")
-  {{accessModifier}} static let allDataAssets: [{{dataType}}] = [
-    {% filter indent:2," ",true %}{% call allValuesBlock assets "data" "" %}{% endfilter %}
-  ]
-  {% endif %}
-  {% set hasItems %}{% call hasValuesBlock assets "image" %}{% endset %}
-  {% if hasItems %}
-  @available(*, deprecated, message: "All values properties are now deprecated")
-  {{accessModifier}} static let allImages: [{{imageType}}] = [
-    {% filter indent:2," ",true %}{% call allValuesBlock assets "image" "" %}{% endfilter %}
-  ]
-  {% endif %}
-  {% set hasItems %}{% call hasValuesBlock assets "symbol" %}{% endset %}
-  {% if hasItems %}
-  @available(*, deprecated, message: "All values properties are now deprecated")
-  {{accessModifier}} static let allSymbols: [{{symbolType}}] = [
-    {% filter indent:2," ",true %}{% call allValuesBlock assets "symbol" "" %}{% endfilter %}
-  ]
-  {% endif %}
-  // swiftlint:enable trailing_comma
-  {% endif %}
 {% endmacro %}
 {% macro casesBlock assets %}
   {% for asset in assets %}
@@ -291,22 +241,6 @@
     return result
   }
   #endif
-}
-
-{{accessModifier}} extension {{imageType}}.Image {
-  @available(iOS 8.0, tvOS 9.0, watchOS 2.0, *)
-  @available(macOS, deprecated,
-    message: "This initializer is unsafe on macOS, please use the {{imageType}}.image property")
-  convenience init?(asset: {{imageType}}) {
-    #if os(iOS) || os(tvOS)
-    let bundle = {{param.bundle|default:"BundleToken.bundle"}}
-    self.init(named: asset.name, in: bundle, compatibleWith: nil)
-    #elseif os(macOS)
-    self.init(named: NSImage.Name(asset.name))
-    #elseif os(watchOS)
-    self.init(named: asset.name)
-    #endif
-  }
 }
 {% endif %}
 {% if hasSymbol %}


### PR DESCRIPTION
## Description
* Implementation removes `mint` package manager in favour of `brew` that is already used. It reduces overall number of dependencies and allows to speed up project bootstrap.
* Latest version of `swiftgen` has broken *xcassets* template when used with deployment target lower than *13* so customized version of template is added to project.
* On Apple Silicon `brew` stores dependencies in `/opt/homebrew/bin` that is not part of PATH for Xcode so `export` is added to fix it.

## Jira Issue
https://checkout.atlassian.net/browse/POM-235
