### PR TITLE
feat(POM-245): deprecate gateway configuration's native APM config

### DIFF
--- a/Example/Example/Sources/UI/Modules/AlternativePayment/Methods/ViewModel/AlternativePaymentMethodsViewModel.swift
+++ b/Example/Example/Sources/UI/Modules/AlternativePayment/Methods/ViewModel/AlternativePaymentMethodsViewModel.swift
@@ -119,7 +119,7 @@ final class AlternativePaymentMethodsViewModel:
                 .contains(gatewayConfiguration.gatewayName ?? "") ?? false
             if !isSubaccount {
                 return
-            } else if prefersNative, gatewayConfiguration.gateway?.nativeApmConfig != nil {
+            } else if prefersNative {
                 let paymentRoute = AlternativePaymentMethodsRoute.NativeAlternativePayment(
                     gatewayConfigurationId: gatewayConfiguration.id,
                     invoiceId: invoice.id,

--- a/Sources/ProcessOut/Sources/Repositories/GatewayConfigurations/Responses/POGatewayConfiguration.swift
+++ b/Sources/ProcessOut/Sources/Repositories/GatewayConfigurations/Responses/POGatewayConfiguration.swift
@@ -39,6 +39,7 @@ public struct POGatewayConfiguration: Decodable {
         public let canRefund: Bool
 
         /// Native alternative payment method configuration.
+        @available(*, deprecated, message: "Use POInvoicesService/nativeAlternativePaymentMethodTransactionDetails(request:) instead.") // swiftlint:disable:this line_length
         public let nativeApmConfig: NativeAlternativePaymentMethodConfig?
     }
 


### PR DESCRIPTION
## Description
Deprecate use of `nativeApmConfig` because it is no longer part of `POGatewayConfiguration`.

## Jira Issue
https://checkout.atlassian.net/browse/POM-245