### PR TITLE
fix(POM-273): date parsing

### DIFF
--- a/Sources/ProcessOut/Sources/Api/Builders/ProcessOutHttpConnectorBuilder.swift
+++ b/Sources/ProcessOut/Sources/Api/Builders/ProcessOutHttpConnectorBuilder.swift
@@ -57,7 +57,6 @@ final class ProcessOutHttpConnectorBuilder {
     // MARK: - Private Nested Types
 
     private enum Constants {
-        static let dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         static let requestTimeout: TimeInterval = 30
     }
 
@@ -65,7 +64,8 @@ final class ProcessOutHttpConnectorBuilder {
 
     private lazy var dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = Constants.dateFormat
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+        dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
         return dateFormatter
     }()


### PR DESCRIPTION
## Description
When parsing fixed format dates locale should be hardcoded to ensure that implementation behaves consistently for all users. For example when user overrides the 24-hour time setting to 12-hour, `DateFormatter` rewrites the format string, which causes time parsing to fail.

For details, see [Technical Q&A QA1480 “NSDateFormatter and Internet Dates”](https://developer.apple.com/library/mac/qa/qa1480/).

## Jira Issue
https://checkout.atlassian.net/browse/POM-272
