### PR TITLE
feat(ad-hoc): support swift package index

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - platform: ios
+      documentation_targets: [ProcessOut, ProcessOutCheckout3DS]

--- a/Scripts/CreateDocumentation.sh
+++ b/Scripts/CreateDocumentation.sh
@@ -29,9 +29,6 @@ function build_doc {(
 mkdir -p $DOCC_TARGET_OUTPUT_DIR
 mkdir -p $DOCC_OUTPUT_DIR
 
-# Remove @_exported imports to avoid exposing unwanted symbols
-find . -type f -path './Sources/*' -name '*.swift' | xargs sed -Ei "" 's/@_exported import/import/g'
-
 # Generate documentation for the primary 'ProcessOut' target
 build_doc "ProcessOut" "$DOCC_OUTPUT_DIR"
 

--- a/Sources/ProcessOutCheckout3DS/Sources/Builder/POCheckout3DSServiceBuilder.swift
+++ b/Sources/ProcessOutCheckout3DS/Sources/Builder/POCheckout3DSServiceBuilder.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-@_exported import ProcessOut
-@_exported import Checkout3DS
+import ProcessOut
+import Checkout3DS
 
 /// Builder to configure and create service capable of handling 3DS challenges using Checkout3DS SDK.
 public final class POCheckout3DSServiceBuilder {


### PR DESCRIPTION
## Description
Implementation adds [Swift Package Index](https://swiftpackageindex.com/processout/processout-ios) manifest to make sure that service will generate proper documentation.

> **Warning**
>
> ProcessOutCheckout3DS imports are no longer exported.

## Jira Issue
\-
