### PR TITLE
fix(ad-hoc): fix Checkout3DS podspec push

### DIFF
--- a/ProcessOutCheckout3DS.podspec
+++ b/ProcessOutCheckout3DS.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.requires_arc          = true
   s.ios.deployment_target = '12.0'
   s.source_files          = 'Sources/ProcessOutCheckout3DS/**/*.swift'
+  s.pod_target_xcconfig   = { 'EXCLUDED_ARCHS' => 'x86_64' }
   s.dependency            'ProcessOut', s.version.to_s
   s.dependency            'Checkout3DS', '3.2.1'
 end


### PR DESCRIPTION
## Description
Checkout3DS only supports arm64 so x86_64 should be excluded

## Jira Issue
\-
