### PR TITLE
fix(POM-281): fix test script

### DIFF
--- a/Scripts/Test.sh
+++ b/Scripts/Test.sh
@@ -6,7 +6,7 @@ PROJECT='ProcessOut.xcodeproj'
 DESTINATION=$(python3 ./Scripts/TestDestination.py)
 
 # Run Tests
-for PRODUCT in "ProcessOut" "ProcessOutUI"; do
+for PRODUCT in "ProcessOut"; do
     xcodebuild clean test \
         -destination "$DESTINATION" \
         -project $PROJECT \

--- a/Scripts/Test.sh
+++ b/Scripts/Test.sh
@@ -3,14 +3,14 @@
 set -euo pipefail
 
 PROJECT='ProcessOut.xcodeproj'
+DESTINATION=$(python3 ./Scripts/TestDestination.py)
 
 # Run Tests
-for PRODUCT in "ProcessOut" ; do
+for PRODUCT in "ProcessOut" "ProcessOutUI"; do
     xcodebuild clean test \
+        -destination "$DESTINATION" \
         -project $PROJECT \
-        -scheme $PRODUCT \
-        -sdk 'iphonesimulator17.0' \
-        -destination 'platform=iOS Simulator,name=iPhone 15'
+        -scheme $PRODUCT
 done
 
 # It is a known issue that Checkout3DS v3.2.1 (framework that ProcessOutCheckout3DS

--- a/Scripts/TestDestination.py
+++ b/Scripts/TestDestination.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+
+import subprocess
+import json
+from pkg_resources import parse_version
+
+# Constants
+min_version = parse_version("17")
+
+# Get valid runtime
+def is_valid_runtime(runtime):
+  version = parse_version(runtime["version"])
+  return runtime["platform"] == "iOS" and version >= min_version
+
+runtimes_description = subprocess.check_output("xcrun simctl list runtimes -j", shell=True).decode("utf-8")
+runtimes = json.loads(runtimes_description)["runtimes"]
+
+valid_runtimes = filter(is_valid_runtime, runtimes)
+valid_runtime_id = next(valid_runtimes)["identifier"]
+
+# Get valid device
+devices_description = subprocess.check_output("xcrun simctl list devices -j", shell=True).decode("utf-8")
+devices = json.loads(devices_description)["devices"]
+
+valid_device_id = devices[valid_runtime_id][0]["udid"]
+
+# Write output
+print("platform=iOS Simulator,id=" + valid_device_id)

--- a/Scripts/TestDestination.py
+++ b/Scripts/TestDestination.py
@@ -2,15 +2,14 @@
 
 import subprocess
 import json
-from pkg_resources import parse_version
 
 # Constants
-min_version = parse_version("17")
+min_major_version = "17"
 
 # Get valid runtime
 def is_valid_runtime(runtime):
-  version = parse_version(runtime["version"])
-  return runtime["platform"] == "iOS" and version >= min_version
+  is_version_valid = runtime["version"].startswith(min_major_version)
+  return runtime["platform"] == "iOS" and is_version_valid == True
 
 runtimes_description = subprocess.check_output("xcrun simctl list runtimes -j", shell=True).decode("utf-8")
 runtimes = json.loads(runtimes_description)["runtimes"]


### PR DESCRIPTION
## Description
For some reason xcodebuild fails to resolve proper destination given only platform and iOS version which causes tests to fail. As a workaround implementation uses `xcrun simctl list` to find needed platform and device manually. And then uses resolved device id as a destination which seems to work fine.

## Jira Issue
https://checkout.atlassian.net/browse/POM-281