### PR TITLE
fix(ad-hoc): UI modules podspec

### DIFF
--- a/ProcessOutCoreUI.podspec
+++ b/ProcessOutCoreUI.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source                = { :git => 'https://github.com/processout/processout-ios.git', :tag => s.version.to_s }
   s.frameworks            = 'Foundation', 'SwiftUI'
   s.ios.deployment_target = '14.0'
-  s.vendored_frameworks   = "Vendor/cmark.xcframework"
   s.ios.resources         = 'Sources/ProcessOutCoreUI/Resources/**/*'
   s.source_files          = 'Sources/ProcessOutCoreUI/**/*.swift'
+  s.dependency            'ProcessOut' # todo(andrii-vysotskyi): vendor cmark.xcframework instead after UI migration is completed
 end

--- a/Scripts/PushPodspecs.sh
+++ b/Scripts/PushPodspecs.sh
@@ -5,7 +5,7 @@
 set +e
 
 # Push Podspecs
-for PRODUCT in "ProcessOut" "ProcessOutCheckout3DS"; do
+for PRODUCT in "ProcessOut" "ProcessOutCoreUI" "ProcessOutUI" "ProcessOutCheckout3DS"; do
 
   # This script is intended to be run on CI where cocoapods is already installed.
   pod trunk push $PRODUCT.podspec --allow-warnings --synchronous

--- a/Scripts/Test.sh
+++ b/Scripts/Test.sh
@@ -10,7 +10,8 @@ for PRODUCT in "ProcessOut" "ProcessOutUI"; do
     xcodebuild clean test \
         -destination "$DESTINATION" \
         -project $PROJECT \
-        -scheme $PRODUCT |
+        -scheme $PRODUCT \
+        -enableCodeCoverage NO |
         xcpretty
 done
 


### PR DESCRIPTION
## Description
* Depend on `ProcessOut` instead of vendoring cmark framework from `ProcessOutCoreUI` to avoid duplicate symbols error. This is a temporary solution til UI migration is completed
* Ensure all podspecs are pushed during release
* Disable code coverage generation when running tests on CI

## Jira Issue
\-
