### PR TITLE
fix(POS-775): card fingerprint decoding

### DIFF
--- a/Sources/ProcessOut/ProcessOut.docc/ProcessOut.md
+++ b/Sources/ProcessOut/ProcessOut.docc/ProcessOut.md
@@ -119,6 +119,9 @@ Types that describe properties such as shadow and border. And style of higher le
 - ``POImmutableExcludedCodable``
 - ``POImmutableStringCodableDecimal``
 - ``POImmutableStringCodableOptionalDecimal``
+- ``POFallbackDecodable``
+- ``POFallbackValueProvider``
+- ``POEmptyStringProvider``
 - ``PORepository``
 - ``POService``
 - ``POAutoAsync``

--- a/Sources/ProcessOut/Sources/Core/CodingUtils/POFallbackDecodable/POFallbackDecodable.swift
+++ b/Sources/ProcessOut/Sources/Core/CodingUtils/POFallbackDecodable/POFallbackDecodable.swift
@@ -1,0 +1,30 @@
+//
+//  POFallbackDecodable.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 24.11.2023.
+//
+
+import Foundation
+
+/// Allows decoding to fallback to default when value is not present.
+@propertyWrapper
+public struct POFallbackDecodable<Provider: POFallbackValueProvider>: Decodable where Provider.Value: Decodable {
+
+    public var wrappedValue: Provider.Value
+
+    public init(wrappedValue: Provider.Value) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension KeyedDecodingContainer {
+
+    public func decode<P>(
+        _ type: POFallbackDecodable<P>.Type, forKey key: KeyedDecodingContainer<K>.Key
+    ) throws -> POFallbackDecodable<P> {
+        POFallbackDecodable(wrappedValue: try decodeIfPresent(P.Value.self, forKey: key) ?? P.defaultValue)
+    }
+}
+
+extension POFallbackDecodable: Hashable, Equatable where Provider.Value: Hashable { }

--- a/Sources/ProcessOut/Sources/Core/CodingUtils/POFallbackDecodable/POFallbackValueProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/CodingUtils/POFallbackDecodable/POFallbackValueProvider.swift
@@ -1,0 +1,23 @@
+//
+//  POFallbackValueProvider.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 24.11.2023.
+//
+
+import Foundation
+
+/// Contract for providing a default value of a Type.
+public protocol POFallbackValueProvider<Value> {
+
+    associatedtype Value
+
+    /// Default value.
+    static var defaultValue: Value { get }
+}
+
+/// Provides empty string as a fallback.
+public struct POEmptyStringProvider: POFallbackValueProvider {
+
+    public static let defaultValue = ""
+}

--- a/Sources/ProcessOut/Sources/Repositories/Cards/Responses/POCard.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Cards/Responses/POCard.swift
@@ -45,7 +45,9 @@ public struct POCard: Decodable, Hashable {
     public let last4Digits: String
 
     /// Hash value that remains the same for this card even if it is tokenized several times.
-    public let fingerprint: String
+    /// - NOTE: fingerprint is empty string for Apple and Google Pay cards.
+    @POFallbackDecodable<POEmptyStringProvider>
+    public private(set) var fingerprint: String
 
     /// Month of the expiration date.
     public let expMonth: Int

--- a/Tests/ProcessOutTests/Sources/Unit/Core/CodingUtils/FallbackDecodableTests.swift
+++ b/Tests/ProcessOutTests/Sources/Unit/Core/CodingUtils/FallbackDecodableTests.swift
@@ -1,0 +1,54 @@
+//
+//  FallbackDecodableTests.swift
+//  ProcessOutTests
+//
+//  Created by Andrii Vysotskyi on 24.11.2023.
+//
+
+import XCTest
+@testable import ProcessOut
+
+final class FallbackDecodableTests: XCTestCase {
+
+    func test_fallbackDecodable_whenValueIsNotPresent_decodesEmptyString() throws {
+        // Given
+        let decoder = JSONDecoder()
+        let data = Data("{}".utf8)
+
+        // When
+        let container = try decoder.decode(Container.self, from: data)
+
+        // Then
+        XCTAssertTrue(container.value.isEmpty)
+    }
+
+    func test_fallbackDecodable_whenValueIsNull_decodesEmptyString() throws {
+        // Given
+        let decoder = JSONDecoder()
+        let data = Data(#"{ "value": null }"#.utf8)
+
+        // When
+        let container = try decoder.decode(Container.self, from: data)
+
+        // Then
+        XCTAssertTrue(container.value.isEmpty)
+    }
+
+    func test_fallbackDecodable_whenValueIsAvailable_decodesIt() throws {
+        // Given
+        let decoder = JSONDecoder()
+        let data = Data(#"{ "value": "1" }"#.utf8)
+
+        // When
+        let container = try decoder.decode(Container.self, from: data)
+
+        // Then
+        XCTAssertEqual(container.value, "1")
+    }
+}
+
+private struct Container: Decodable {
+
+    @POFallbackDecodable<POEmptyStringProvider>
+    var value: String
+}


### PR DESCRIPTION
## Description
When tokenizing Apple Pay card fingerprint is not set in returned card object. In order to remain backward compatible null fingerprint is decoded as empty string.

## Jira Issue
https://checkout.atlassian.net/browse/POS-775

