### PR TITLE
fix(ad-hoc): remove universal links support

### DIFF
--- a/Example/Example/Sources/Application/SceneDelegate.swift
+++ b/Example/Example/Sources/Application/SceneDelegate.swift
@@ -23,12 +23,6 @@ final class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
     }
 
-    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-        if let url = userActivity.webpageURL {
-            ProcessOut.shared.processDeepLink(url: url)
-        }
-    }
-
     func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
         if let url = urlContexts.first?.url {
             ProcessOut.shared.processDeepLink(url: url)

--- a/Sources/ProcessOut/ProcessOut.docc/3DS.md
+++ b/Sources/ProcessOut/ProcessOut.docc/3DS.md
@@ -36,13 +36,13 @@ func handle(redirect: PO3DSRedirect, completion: @escaping (Result<String, POFai
 }
 ```
 
-When using `PO3DSRedirectViewControllerBuilder` your application should support deep and/or universal links. When
+When using `PO3DSRedirectViewControllerBuilder` your application should support deep links. When
 application receives incoming URL you should allow ProcessOut SDK to handle it. For example if you are using scene
-delegate and universal links it may look like following:
+delegate it may look like following:
 
 ```swift
-func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
-    guard let url = userActivity.webpageURL else {
+func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
+    guard let url = urlContexts.first?.url else {
         return
     }
     let isHandled = ProcessOut.shared.processDeepLink(url: url)

--- a/Sources/ProcessOut/Sources/Api/Models/DeepLinkReceivedEvent.swift
+++ b/Sources/ProcessOut/Sources/Api/Models/DeepLinkReceivedEvent.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct DeepLinkReceivedEvent: EventEmitterEvent {
 
-    /// Url representing deep link or universal link.
+    /// Url representing deep link.
     let url: URL
 }

--- a/Sources/ProcessOut/Sources/Api/ProcessOut.swift
+++ b/Sources/ProcessOut/Sources/Api/ProcessOut.swift
@@ -83,6 +83,7 @@ public final class ProcessOut {
     /// - Returns: `true` if the URL is expected and will be handled by SDK. `false` otherwise.
     @discardableResult
     public func processDeepLink(url: URL) -> Bool {
+        logger.debug("Will process deep link: \(url)")
         let event = DeepLinkReceivedEvent(url: url)
         return eventEmitter.emit(event: event)
     }
@@ -101,7 +102,7 @@ public final class ProcessOut {
     // MARK: - Internal
 
     /// Event emitter to use for events exchange.
-    private(set) lazy var eventEmitter: EventEmitter = LocalEventEmitter()
+    private(set) lazy var eventEmitter: EventEmitter = LocalEventEmitter(logger: logger)
 
     init(configuration: ProcessOutConfiguration) {
         self.configuration = configuration

--- a/Sources/ProcessOut/Sources/Api/ProcessOut.swift
+++ b/Sources/ProcessOut/Sources/Api/ProcessOut.swift
@@ -77,8 +77,8 @@ public final class ProcessOut {
         return DefaultCustomerTokensService(repository: repository, threeDSService: threeDSService)
     }()
 
-    /// Call this method in your app or scene delegate whenever your implementation receives incoming URL. You can pass
-    /// both custom scheme-based deep links and universal links.
+    /// Call this method in your app or scene delegate whenever your implementation receives incoming URL. Only deep
+    /// links are supported.
     ///
     /// - Returns: `true` if the URL is expected and will be handled by SDK. `false` otherwise.
     @discardableResult


### PR DESCRIPTION
## Description
`SFSafariViewController` may decide not to forward universal link to application for example when redirect is performed by JavaScript code. To ensure that 3DS and APM flows are handled reliably, only deep links should be used.

## Jira Issue
\-
