### PR TITLE
feat(ad-hoc): update 3DS SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   run-tests:
-    runs-on: macos-13
+    runs-on: macos-13-xlarge
     steps:
       - uses: actions/checkout@v3
       - name: Bootstrap Project

--- a/Example/Package.resolved
+++ b/Example/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/checkout/checkout-3ds-sdk-ios",
       "state" : {
-        "revision" : "b7f3e53150e45105de58b11e683254ee4ec30913",
-        "version" : "3.2.1"
+        "revision" : "4d03fe0cd2b4415a68262153e7f4762ec34635c8",
+        "version" : "3.2.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/checkout/checkout-3ds-sdk-ios",
       "state" : {
-        "revision" : "b7f3e53150e45105de58b11e683254ee4ec30913",
-        "version" : "3.2.1"
+        "revision" : "4d03fe0cd2b4415a68262153e7f4762ec34635c8",
+        "version" : "3.2.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .library(name: "ProcessOutCheckout3DS", targets: ["ProcessOutCheckout3DS"])
     ],
     dependencies: [
-        .package(url: "https://github.com/checkout/checkout-3ds-sdk-ios", exact: "3.2.1"),
+        .package(url: "https://github.com/checkout/checkout-3ds-sdk-ios", exact: "3.2.2"),
     ],
     targets: [
         .target(

--- a/ProcessOutCheckout3DS.podspec
+++ b/ProcessOutCheckout3DS.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
   s.source_files          = 'Sources/ProcessOutCheckout3DS/**/*.swift'
   s.pod_target_xcconfig   = { 'EXCLUDED_ARCHS' => 'x86_64' }
   s.dependency            'ProcessOut', s.version.to_s
-  s.dependency            'Checkout3DS', '3.2.1'
+  s.dependency            'Checkout3DS', '3.2.2'
 end

--- a/Scripts/Test.sh
+++ b/Scripts/Test.sh
@@ -6,7 +6,7 @@ PROJECT='ProcessOut.xcodeproj'
 DESTINATION=$(./Scripts/TestDestination.swift)
 
 # Run Tests
-for PRODUCT in "ProcessOut" "ProcessOutUI"; do
+for PRODUCT in "ProcessOut" "ProcessOutUI" "ProcessOutCheckout3DS"; do
     xcodebuild clean test \
         -destination "$DESTINATION" \
         -project $PROJECT \
@@ -14,13 +14,5 @@ for PRODUCT in "ProcessOut" "ProcessOutUI"; do
         -enableCodeCoverage NO |
         xcpretty
 done
-
-# It is a known issue that Checkout3DS v3.2.1 (framework that ProcessOutCheckout3DS
-# depends on) can't be properly tested without host application due to bug.
-xcodebuild clean build \
-    -project $PROJECT \
-    -scheme ProcessOutCheckout3DS \
-    -destination "generic/platform=iOS" |
-    xcpretty
 
 # todo(andrii-vysotskyi): run example target tests when POM-144 is resolved

--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.1.2 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.1.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation

--- a/Tests/ProcessOutTests/Sources/Integration/CardsServiceTests.swift
+++ b/Tests/ProcessOutTests/Sources/Integration/CardsServiceTests.swift
@@ -24,7 +24,7 @@ import XCTest
         let information = try await sut.issuerInformation(iin: "400012")
 
         // Then
-        XCTAssertEqual(information.bankName, "BANK OF AMERICA NATIONAL ASSOCIATION")
+        XCTAssertEqual(information.bankName, "UNITED CITIZENS BANK OF SOUTHERN KENTUCKY")
         XCTAssertEqual(information.brand, "visa business")
         XCTAssertEqual(information.category, "commercial")
         XCTAssertEqual(information.scheme, "visa")

--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,7 @@ options:
 packages:
   Checkout3DSPackages:
     url: https://github.com/checkout/checkout-3ds-sdk-ios
-    version: 3.2.1
+    version: 3.2.2
 targets:
   ProcessOutCoreUI:
     type: framework


### PR DESCRIPTION
## Description
CKO deprecated version `3.2.1`, so we are upgrading to the most recent [`3.2.2`](https://github.com/checkout/checkout-3ds-sdk-ios/releases/tag/3.2.2). This version also fixes inability to test target without host application, so workaround is removed.

## Jira Issue
\-
