### PR TITLE
feat(POM-336): allow retrying form submission

### DIFF
--- a/Sources/ProcessOutUI/Sources/Modules/3DSRedirect/PO3DSRedirectController.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/3DSRedirect/PO3DSRedirectController.swift
@@ -67,9 +67,9 @@ public final class PO3DSRedirectController {
 
     /// Dismisses the Redirect UI.
     public func dismiss(completion: (() -> Void)? = nil) {
-        if let presentingViewController = safariViewController?.presentingViewController {
-            safariViewController = nil
-            presentingViewController.dismiss(animated: true, completion: completion)
+        if let safariViewController, safariViewController.presentingViewController != nil {
+            self.safariViewController = nil
+            safariViewController.dismiss(animated: true, completion: completion)
         } else {
             completion?()
         }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -116,3 +116,20 @@ enum CardTokenizationInteractorState {
     /// Card tokenization did end with unrecoverable failure. This is a sink state.
     case failure(POFailure)
 }
+
+extension CardTokenizationInteractorState.AddressParameters {
+
+    /// Boolean value that allows to determine whether all parameters are valid.
+    var areParametersValid: Bool {
+        [country, street1, street2, city, state, postalCode].allSatisfy(\.isValid)
+    }
+}
+
+extension CardTokenizationInteractorState.Started {
+
+    /// Boolean value that allows to determine whether all parameters are valid.
+    var areParametersValid: Bool {
+        let parameters = [number, expiration, cvc, cardholderName]
+        return parameters.allSatisfy(\.isValid) && address.areParametersValid
+    }
+}

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -68,7 +68,7 @@ final class DefaultCardTokenizationInteractor:
         }
         startedState[keyPath: parameterId].value = formattedValue
         startedState[keyPath: parameterId].isValid = true
-        if areParametersValid(startedState: startedState) {
+        if startedState.areParametersValid {
             logger.debug("Card information is no longer invalid, will reset error message")
             startedState.recentErrorMessage = nil
         }
@@ -105,7 +105,7 @@ final class DefaultCardTokenizationInteractor:
         guard case .started(let startedState) = state else {
             return
         }
-        guard areParametersValid(startedState: startedState), startedState.recentErrorMessage == nil else {
+        guard startedState.areParametersValid else {
             logger.debug("Ignoring attempt to tokenize invalid parameters.")
             return
         }
@@ -407,24 +407,6 @@ final class DefaultCardTokenizationInteractor:
             return parameter.value
         }
         return defaultValue
-    }
-
-    // MARK: - Utils
-
-    private func areParametersValid(startedState: State.Started) -> Bool {
-        let parameters = [
-            startedState.number,
-            startedState.expiration,
-            startedState.cvc,
-            startedState.cardholderName,
-            startedState.address.country,
-            startedState.address.street1,
-            startedState.address.street2,
-            startedState.address.city,
-            startedState.address.state,
-            startedState.address.postalCode
-        ]
-        return parameters.allSatisfy(\.isValid)
     }
 }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -315,7 +315,7 @@ final class DefaultCardTokenizationViewModel: CardTokenizationViewModel {
         let action = POActionsContainerActionViewModel(
             id: "primary-button",
             title: configuration.primaryActionTitle ?? String(resource: .CardTokenization.Button.submit),
-            isEnabled: startedState.recentErrorMessage == nil,
+            isEnabled: startedState.areParametersValid,
             isLoading: isSubmitting,
             isPrimary: true,
             action: { [weak self] in

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractorState.swift
@@ -30,6 +30,10 @@ enum CardUpdateInteractorState: Equatable {
         /// Formatter that should be used to format CVC.
         var formatter: Formatter?
 
+        /// Indicates whether parameters are valid.
+        /// - NOTE: CVC is the only parameter that could be invalid at a moment.
+        var areParametersValid = true
+
         /// The most recent error message.
         var recentErrorMessage: String?
     }

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
@@ -53,6 +53,7 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
             logger.debug("Ignoring same CVC value \(formatted)")
             return
         }
+        startedState.areParametersValid = true
         startedState.recentErrorMessage = nil
         startedState.cvc = formatted
         state = .started(startedState)
@@ -81,8 +82,8 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         guard case .started(let startedState) = state else {
             return
         }
-        guard startedState.recentErrorMessage == nil else {
-            logger.debug("Ignoring attempt to submit invalid CVC")
+        guard startedState.areParametersValid else {
+            logger.debug("Ignoring attempt to submit invalid parameters.")
             return
         }
         logger.debug("Will submit card information")
@@ -224,8 +225,10 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
              .generic(.cardInvalidCvc),
              .generic(.cardFailedCvc),
              .generic(.cardFailedCvcAndAvs):
+            startedState.areParametersValid = false
             errorMessage = .CardUpdate.Error.cvc
         default:
+            startedState.areParametersValid = true
             errorMessage = .CardUpdate.Error.generic
         }
         // todo(andrii-vysotskyi): remove hardcoded message when backend is updated with localized values

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/DefaultCardUpdateViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/DefaultCardUpdateViewModel.swift
@@ -138,7 +138,7 @@ final class DefaultCardUpdateViewModel: CardUpdateViewModel {
                 }
             ),
             placeholder: String(resource: .CardUpdate.cvc),
-            isInvalid: state.recentErrorMessage != nil,
+            isInvalid: !state.areParametersValid,
             isEnabled: true,
             icon: Image(.Card.back),
             formatter: state.formatter,
@@ -195,7 +195,7 @@ final class DefaultCardUpdateViewModel: CardUpdateViewModel {
 
     private func updateActions(with state: InteractorState.Started, isSubmitting: Bool = false) {
         let actions = [
-            submitAction(isEnabled: state.recentErrorMessage == nil, isLoading: isSubmitting),
+            submitAction(isEnabled: state.areParametersValid, isLoading: isSubmitting),
             cancelAction(isEnabled: !isSubmitting)
         ]
         self.actions = actions.compactMap { $0 }


### PR DESCRIPTION
## Description
* Allow retrying submission without forcing user to modify inputs if returned error is unrelated to inputs. Such as when network failures occur. Changes are affecting card tokenization and update.
* Fix 3DS redirect controller dismiss when flow is manually cancelled.

https://github.com/processout/processout-ios/assets/114918645/dca438b4-fdea-4af6-9599-5eecfae917ce

## Jira Issue
https://checkout.atlassian.net/browse/POM-336
