### PR TITLE
fix(ad-hoc): user agent system name

### DIFF
--- a/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
+++ b/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
@@ -100,7 +100,7 @@ final class DefaultHttpConnectorRequestMapper: HttpConnectorRequestMapper {
             "Authorization": authorization(request: request),
             "Installation-Id": deviceMetadata.installationId,
             "Device-Id": deviceMetadata.id,
-            "Device-System-Name": deviceMetadata.channel.lowercased(),
+            "Device-System-Name": deviceMetadata.channel,
             "Device-System-Version": deviceMetadata.systemVersion,
             "Product-Version": configuration.version,
             "Host-Application-Version": configuration.appVersion

--- a/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
+++ b/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
@@ -110,7 +110,7 @@ final class DefaultHttpConnectorRequestMapper: HttpConnectorRequestMapper {
 
     private func userAgent(deviceMetadata: DeviceMetadata) -> String {
         let components = [
-            deviceMetadata.channel,
+            "iOS",
             deviceMetadata.systemVersion + " ProcessOut iOS-Bindings",
             configuration.version
         ]

--- a/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
+++ b/Sources/ProcessOut/Sources/Connectors/Http/Implementations/UrlSession/RequestMapper/DefaultHttpConnectorRequestMapper.swift
@@ -100,7 +100,7 @@ final class DefaultHttpConnectorRequestMapper: HttpConnectorRequestMapper {
             "Authorization": authorization(request: request),
             "Installation-Id": deviceMetadata.installationId,
             "Device-Id": deviceMetadata.id,
-            "Device-System-Name": deviceMetadata.channel,
+            "Device-System-Name": deviceMetadata.channel.lowercased(),
             "Device-System-Version": deviceMetadata.systemVersion,
             "Product-Version": configuration.version,
             "Host-Application-Version": configuration.appVersion

--- a/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
@@ -56,7 +56,7 @@ actor DefaultDeviceMetadataProvider: DeviceMetadataProvider {
             appScreenWidth: Int(screen.nativeBounds.width), // Specified in pixels
             appScreenHeight: Int(screen.nativeBounds.height),
             appTimeZoneOffset: TimeZone.current.secondsFromGMT() / 60,
-            channel: device.systemName.lowercased()
+            channel: device.systemName
         )
     }
 }

--- a/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
@@ -56,7 +56,7 @@ actor DefaultDeviceMetadataProvider: DeviceMetadataProvider {
             appScreenWidth: Int(screen.nativeBounds.width), // Specified in pixels
             appScreenHeight: Int(screen.nativeBounds.height),
             appTimeZoneOffset: TimeZone.current.secondsFromGMT() / 60,
-            channel: device.systemName
+            channel: device.systemName.lowercased()
         )
     }
 }

--- a/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
+++ b/Sources/ProcessOut/Sources/Core/DeviceMetadata/DefaultDeviceMetadataProvider.swift
@@ -56,7 +56,7 @@ actor DefaultDeviceMetadataProvider: DeviceMetadataProvider {
             appScreenWidth: Int(screen.nativeBounds.width), // Specified in pixels
             appScreenHeight: Int(screen.nativeBounds.height),
             appTimeZoneOffset: TimeZone.current.secondsFromGMT() / 60,
-            channel: device.systemName.lowercased()
+            channel: "ios"
         )
     }
 }

--- a/Tests/ProcessOutTests/Sources/Unit/Connectors/Http/DefaultHttpConnectorRequestMapperTests.swift
+++ b/Tests/ProcessOutTests/Sources/Unit/Connectors/Http/DefaultHttpConnectorRequestMapperTests.swift
@@ -125,7 +125,7 @@ final class DefaultHttpConnectorRequestMapperTests: XCTestCase {
 
         // Then
         let userAgent = urlRequest.value(forHTTPHeaderField: "user-agent")
-        let userAgentRegex = /^test\/4 ProcessOut iOS-Bindings\/1\.2\.3$/
+        let userAgentRegex = /^iOS\/4 ProcessOut iOS-Bindings\/1\.2\.3$/
         XCTAssertNotNil(userAgent?.firstMatch(of: userAgentRegex))
     }
 


### PR DESCRIPTION
## Description
* User-agent is hardcoded to start with `iOS`
* `Device/channel` may report value unexpected by backend, such as iPadOS so was hardcoded to `ios`

## Jira Issue
\-
