### PR TITLE
fix(POM-346): SwiftGen integration

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -3,6 +3,6 @@ tap "lokalise/cli-2"
 
 brew "xcodegen"
 brew "swiftlint"
-brew "swiftgen"
 brew "sourcery"
 brew "lokalise2"
+brew "mint"

--- a/Example/Brewfile
+++ b/Example/Brewfile
@@ -1,3 +1,3 @@
 brew "xcodegen"
 brew "swiftlint"
-brew "swiftgen"
+brew "mint"

--- a/Example/Scripts/BootstrapProject.sh
+++ b/Example/Scripts/BootstrapProject.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Installs brew dependencies
 brew bundle -q
 
+# SwiftGen is broken with Brew so installed with Mint instead
+mint install SwiftGen/SwiftGen
+
 # Generates project
 xcodegen generate
 

--- a/Example/Scripts/SwiftGen/SwiftGen.sh
+++ b/Example/Scripts/SwiftGen/SwiftGen.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 export PATH="/opt/homebrew/bin:$PATH"
 
 # Run SwiftGen
-swiftgen config run
+mint run swiftgen config run

--- a/Scripts/BootstrapProject.sh
+++ b/Scripts/BootstrapProject.sh
@@ -8,5 +8,8 @@ export CURRENT_VERSION="$(cat Version.resolved)"
 # Installs brew dependencies
 brew bundle -q
 
+# SwiftGen is broken with Brew so installed with Mint instead
+mint install SwiftGen/SwiftGen
+
 # Creates project
 xcodegen generate

--- a/Scripts/SwiftGen.sh
+++ b/Scripts/SwiftGen.sh
@@ -6,4 +6,4 @@ set -euo pipefail
 export PATH="/opt/homebrew/bin:$PATH"
 
 # Run SwiftGen
-swiftgen config run --config "${TARGET_ROOT}/swiftgen.yml"
+mint run swiftgen config run --config "${TARGET_ROOT}/swiftgen.yml"


### PR DESCRIPTION
## Description
SwiftGen is disabled with Homebrew so currently can't be installed (see issue [here](https://github.com/SwiftGen/SwiftGen/issues/1104)). Temporary workaround is to install it with `mint`.

## Jira Issue
https://checkout.atlassian.net/browse/POM-346
