### PR TITLE
feat(ad-hoc): pass merchant identifier when tokenizing ApplePay

### DIFF
--- a/Sources/ProcessOut/Sources/Repositories/Cards/Requests/ApplePayCardTokenizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Cards/Requests/ApplePayCardTokenizationRequest.swift
@@ -64,6 +64,9 @@ struct ApplePayCardTokenizationRequest: Encodable {
     /// Additional metadata.
     let metadata: [String: String]?
 
+    /// Merchant identifier.
+    let applepayMid: String?
+
     /// Payment information.
     let applepayResponse: ApplePay
 }

--- a/Sources/ProcessOut/Sources/Services/Cards/Mappers/ApplePayCardTokenizationRequest/DefaultApplePayCardTokenizationRequestMapper.swift
+++ b/Sources/ProcessOut/Sources/Services/Cards/Mappers/ApplePayCardTokenizationRequest/DefaultApplePayCardTokenizationRequestMapper.swift
@@ -33,6 +33,7 @@ final class DefaultApplePayCardTokenizationRequestMapper: ApplePayCardTokenizati
                 tokenType: "applepay",
                 contact: request.contact,
                 metadata: request.metadata,
+                applepayMid: request.merchantIdentifier,
                 applepayResponse: .init(token: token)
             )
             return tokenizationRequest

--- a/Sources/ProcessOut/Sources/Services/Cards/Requests/POApplePayCardTokenizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Services/Cards/Requests/POApplePayCardTokenizationRequest.swift
@@ -14,8 +14,8 @@ public struct POApplePayCardTokenizationRequest {
     /// Payment information.
     public let payment: PKPayment
 
-    /// Identifies the merchant, as previously agreed with Apple. Must match one of the merchant
-    /// identifiers in the application's entitlement.
+    /// Identifies the merchant, as previously agreed with Apple. Must match `PKPaymentRequest/merchantIdentifier`
+    /// that was used to produce `PKPayment`.
     public let merchantIdentifier: String?
 
     /// Contact information.

--- a/Sources/ProcessOut/Sources/Services/Cards/Requests/POApplePayCardTokenizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Services/Cards/Requests/POApplePayCardTokenizationRequest.swift
@@ -14,14 +14,24 @@ public struct POApplePayCardTokenizationRequest {
     /// Payment information.
     public let payment: PKPayment
 
+    /// Identifies the merchant, as previously agreed with Apple. Must match one of the merchant
+    /// identifiers in the application's entitlement.
+    public let merchantIdentifier: String?
+
     /// Contact information.
     public let contact: POContact?
 
     /// Additional matadata.
     public let metadata: [String: String]?
 
-    public init(payment: PKPayment, contact: POContact? = nil, metadata: [String: String]? = nil) {
+    public init(
+        payment: PKPayment,
+        merchantIdentifier: String? = nil,
+        contact: POContact? = nil,
+        metadata: [String: String]? = nil
+    ) {
         self.payment = payment
+        self.merchantIdentifier = merchantIdentifier
         self.contact = contact
         self.metadata = metadata
     }

--- a/Sources/ProcessOutUI/Sources/Modules/PassKitPaymentAuthorization/POPassKitPaymentAuthorizationController.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/PassKitPaymentAuthorization/POPassKitPaymentAuthorizationController.swift
@@ -111,6 +111,7 @@ extension POPassKitPaymentAuthorizationController: PKPaymentAuthorizationControl
     ) async -> PKPaymentAuthorizationResult {
         let request = POApplePayCardTokenizationRequest(
             payment: payment,
+            merchantIdentifier: paymentRequest.merchantIdentifier,
             contact: payment.billingContact.flatMap(contactMapper.map),
             metadata: nil // todo(andrii-vysotskyi): decide if metadata injection should be allowed
         )


### PR DESCRIPTION
## Description
When merchant identifier is not explicitly set backend implementation attempts to resolve default config which is not always what we want. Solution is to pass merchant ID explicitly with Apple Pay request.

## Jira Issue
\-
