### PR TITLE
fix(POM-353): privacy manifest

### DIFF
--- a/Sources/ProcessOutCheckout3DS/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ProcessOutCheckout3DS/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/Sources/ProcessOutCoreUI/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/ProcessOutCoreUI/Resources/PrivacyInfo.xcprivacy
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>


### PR DESCRIPTION
## Description
Privacy manifest must define `NSPrivacyCollectedDataTypes` key, even if value is empty array. `Checkout3DS` and `CoreUI` manifests were updates to reflect that.

## Jira Issue
https://checkout.atlassian.net/browse/POM-353