### PR TITLE
fix(POM-360): `enableThreeDS2` parameter encoding

### DIFF
--- a/Scripts/Sourcery.sh
+++ b/Scripts/Sourcery.sh
@@ -8,6 +8,6 @@ export PATH="/opt/homebrew/bin:$PATH"
 # Run sourcery
 sourcery \
   --sources $PROJECT_DIR/Sources/$TARGET_NAME/Sources \
-  --templates $PROJECT_DIR/Templates/AutoCompletion.stencil \
+  --templates $PROJECT_DIR/Templates \
   --parseDocumentation \
   --output $PROJECT_DIR/Sources/$TARGET_NAME/Sources/Generated/Sourcery+Generated.swift

--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -15,7 +15,7 @@ extension POAssignCustomerTokenRequest {
         case preferredScheme
         case verify
         case invoiceId
-        case enableThreeDS2
+        case enableThreeDS2 = "enable_three_d_s_2"
         case thirdPartySdkVersion
         case metadata
     }
@@ -27,7 +27,7 @@ extension POInvoiceAuthorizationRequest {
         case invoiceId
         case source
         case incremental
-        case enableThreeDS2
+        case enableThreeDS2 = "enable_three_d_s_2"
         case preferredScheme
         case thirdPartySdkVersion
         case invoiceDetailIds

--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -1,10 +1,47 @@
-// Generated using Sourcery 2.1.7 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation
 import UIKit
 
-// swiftlint:disable all
+// MARK: - AutoCodingKeys
+
+extension POAssignCustomerTokenRequest {
+
+    enum CodingKeys: String, CodingKey {
+        case customerId
+        case tokenId
+        case source
+        case preferredScheme
+        case verify
+        case invoiceId
+        case enableThreeDS2
+        case thirdPartySdkVersion
+        case metadata
+    }
+}
+
+extension POInvoiceAuthorizationRequest {
+
+    enum CodingKeys: String, CodingKey {
+        case invoiceId
+        case source
+        case incremental
+        case enableThreeDS2
+        case preferredScheme
+        case thirdPartySdkVersion
+        case invoiceDetailIds
+        case overrideMacBlocking
+        case initialSchemeTransactionId
+        case autoCaptureAt
+        case captureAmount
+        case authorizeOnly
+        case allowFallbackToSale
+        case metadata
+    }
+}
+
+// MARK: - AutoCompletion
 
 extension POCardsService {
 

--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -9,8 +9,6 @@ import UIKit
 extension POAssignCustomerTokenRequest {
 
     enum CodingKeys: String, CodingKey {
-        case customerId
-        case tokenId
         case source
         case preferredScheme
         case verify
@@ -24,7 +22,6 @@ extension POAssignCustomerTokenRequest {
 extension POInvoiceAuthorizationRequest {
 
     enum CodingKeys: String, CodingKey {
-        case invoiceId
         case source
         case incremental
         case enableThreeDS2 = "enable_three_d_s_2"

--- a/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Request to use to assign new source to existing customer token and potentially verify it.
-public struct POAssignCustomerTokenRequest: Encodable {
+public struct POAssignCustomerTokenRequest: Encodable { // sourcery: AutoCodingKeys
 
     /// Id of the customer who token belongs to.
     @POImmutableExcludedCodable

--- a/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
@@ -34,7 +34,7 @@ public struct POAssignCustomerTokenRequest: Encodable { // sourcery: AutoCodingK
     public let invoiceId: String?
 
     /// Boolean value indicating whether 3DS2 is enabled. Default value is `true`.
-    public let enableThreeDS2: Bool
+    public let enableThreeDS2: Bool // sourcery:coding: key="enable_three_d_s_2"
 
     /// Can be used for a 3DS2 request to indicate which third party SDK is used for the call.
     public let thirdPartySdkVersion: String?

--- a/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/CustomerTokens/Requests/POAssignCustomerTokenRequest.swift
@@ -11,12 +11,10 @@ import Foundation
 public struct POAssignCustomerTokenRequest: Encodable { // sourcery: AutoCodingKeys
 
     /// Id of the customer who token belongs to.
-    @POImmutableExcludedCodable
-    public var customerId: String
+    public let customerId: String // sourcery:coding: skip
 
     /// Tokens that belong to the customer.
-    @POImmutableExcludedCodable
-    public var tokenId: String
+    public let tokenId: String // sourcery:coding: skip
 
     /// Payment source to associate with token. The source can be a card, an APM or a gateway request. For the source
     /// to be valid, you must not have used it for any previous payment or to create any other customer tokens.
@@ -54,8 +52,8 @@ public struct POAssignCustomerTokenRequest: Encodable { // sourcery: AutoCodingK
         thirdPartySdkVersion: String? = nil,
         metadata: [String: String]? = nil
     ) {
-        self._customerId = .init(value: customerId)
-        self._tokenId = .init(value: tokenId)
+        self.customerId = customerId
+        self.tokenId = tokenId
         self.source = source
         self.preferredScheme = preferredScheme
         self.verify = verify

--- a/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public struct POInvoiceAuthorizationRequest: Encodable {
+public struct POInvoiceAuthorizationRequest: Encodable { // sourcery: AutoCodingKeys
 
     /// Invoice identifier to to perform authorization for.
     @POImmutableExcludedCodable

--- a/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
@@ -10,8 +10,7 @@ import Foundation
 public struct POInvoiceAuthorizationRequest: Encodable { // sourcery: AutoCodingKeys
 
     /// Invoice identifier to to perform authorization for.
-    @POImmutableExcludedCodable
-    public var invoiceId: String
+    public let invoiceId: String // sourcery:coding: skip
 
     /// Payment source to use for authorization.
     public let source: String
@@ -75,7 +74,7 @@ public struct POInvoiceAuthorizationRequest: Encodable { // sourcery: AutoCoding
         allowFallbackToSale: Bool = false,
         metadata: [String: String]? = nil
     ) {
-        self._invoiceId = .init(value: invoiceId)
+        self.invoiceId = invoiceId
         self.source = source
         self.incremental = incremental
         self.enableThreeDS2 = enableThreeDS2

--- a/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Invoices/Requests/POInvoiceAuthorizationRequest.swift
@@ -20,7 +20,7 @@ public struct POInvoiceAuthorizationRequest: Encodable { // sourcery: AutoCoding
     public let incremental: Bool
 
     /// Boolean value indicating whether 3DS2 is enabled. Default value is `true`.
-    public let enableThreeDS2: Bool
+    public let enableThreeDS2: Bool // sourcery:coding: key="enable_three_d_s_2"
 
     /// Card scheme or co-scheme that should get priority if it is available.
     public let preferredScheme: String?

--- a/Templates/Auto.stencil
+++ b/Templates/Auto.stencil
@@ -1,0 +1,2 @@
+import Foundation
+import UIKit

--- a/Templates/AutoCodingKeys.stencil
+++ b/Templates/AutoCodingKeys.stencil
@@ -5,7 +5,7 @@ extension {{ type.name }} {
 
     enum CodingKeys: String, CodingKey {
         {% for variable in type.instanceVariables %}
-        case {{ variable.name }}
+        case {{ variable.name }}{% if variable.annotations.coding.key %} = "{{ variable.annotations.coding.key }}"{% endif %}
         {% endfor %}
     }
 }

--- a/Templates/AutoCodingKeys.stencil
+++ b/Templates/AutoCodingKeys.stencil
@@ -1,0 +1,12 @@
+// MARK: - AutoCodingKeys
+{% for type in types.all|annotated:"AutoCodingKeys" %}
+
+extension {{ type.name }} {
+
+    enum CodingKeys: String, CodingKey {
+        {% for variable in type.instanceVariables %}
+        case {{ variable.name }}
+        {% endfor %}
+    }
+}
+{% endfor %}

--- a/Templates/AutoCodingKeys.stencil
+++ b/Templates/AutoCodingKeys.stencil
@@ -4,7 +4,7 @@
 extension {{ type.name }} {
 
     enum CodingKeys: String, CodingKey {
-        {% for variable in type.instanceVariables %}
+        {% for variable in type.instanceVariables where not variable.annotations.coding.skip %}
         case {{ variable.name }}{% if variable.annotations.coding.key %} = "{{ variable.annotations.coding.key }}"{% endif %}
         {% endfor %}
     }

--- a/Templates/AutoCompletion.stencil
+++ b/Templates/AutoCompletion.stencil
@@ -1,7 +1,4 @@
-import Foundation
-import UIKit
-
-// swiftlint:disable all
+// MARK: - AutoCompletion
 {% for type in types.implementing.POAutoCompletion|protocol %}
 
 extension {{ type.name }} {

--- a/Tests/ProcessOutTests/Sources/Integration/CardsServiceTests.swift
+++ b/Tests/ProcessOutTests/Sources/Integration/CardsServiceTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 @testable import ProcessOut
 
-@MainActor final class CardsServiceTests: XCTestCase {
+final class CardsServiceTests: XCTestCase {
 
     override func setUp() {
         super.setUp()

--- a/Tests/ProcessOutTests/Sources/Integration/CustomerTokensServiceTests.swift
+++ b/Tests/ProcessOutTests/Sources/Integration/CustomerTokensServiceTests.swift
@@ -8,7 +8,7 @@
 import XCTest
 @_spi(PO) @testable import ProcessOut
 
-@MainActor final class CustomerTokensServiceTests: XCTestCase {
+final class CustomerTokensServiceTests: XCTestCase {
 
     override func setUp() {
         super.setUp()

--- a/Tests/ProcessOutTests/Sources/Integration/GatewayConfigurationsRepositoryTests.swift
+++ b/Tests/ProcessOutTests/Sources/Integration/GatewayConfigurationsRepositoryTests.swift
@@ -9,7 +9,7 @@ import Foundation
 import XCTest
 @testable import ProcessOut
 
-@MainActor final class GatewayConfigurationsRepositoryTests: XCTestCase {
+final class GatewayConfigurationsRepositoryTests: XCTestCase {
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
## Description
By default iOS encodes `let enableThreeDS2` key as `"enable_three_ds2"` when strategy is set to `convertToSnakeCase`. But backend expects it to be `enable_three_d_s_2`.

Solution was to define custom `CodingKeys`. In order to avoid re-defining all coding keys `AutoCodingKeys.stencil` template was added.

## Jira Issue
https://checkout.atlassian.net/browse/POM-355