### PR TITLE
fix(ad-hoc): retain authentication session

### DIFF
--- a/Sources/ProcessOutUI/Sources/Modules/WebAuthentication/POWebAuthenticationSession.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/WebAuthentication/POWebAuthenticationSession.swift
@@ -33,6 +33,7 @@ public final class POWebAuthenticationSession {
         await withCheckedContinuation { continuation in
             presentingViewController.present(viewController, animated: true, completion: continuation.resume)
         }
+        associate(controller: self, with: viewController)
         return true
     }
 


### PR DESCRIPTION
## Description
While merging code that was responsible for retaining auth session for the duration of presentation was removed. This fix addresses that.

## Jira Issue
\-
