### PR TITLE
fix(ad-hoc): attributed string markdown

### DIFF
--- a/Sources/ProcessOutCoreUI/Sources/Core/AttributedStringBuilder/AttributedStringMarkdownVisitor.swift
+++ b/Sources/ProcessOutCoreUI/Sources/Core/AttributedStringBuilder/AttributedStringMarkdownVisitor.swift
@@ -169,6 +169,9 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
         // we are additionally increasing calculated width.
         let marker = textList.marker(forItemNumber: textList.startingItemNumber + itemsCount - 1)
         let indentation = builder
+            .with { builder in
+                builder.fontFeatures.numberSpacing = .monospaced
+            }
             .build(string: marker)
             .size()
             .width + Constants.listMarkerWidthIncrement

--- a/Sources/ProcessOutCoreUI/Sources/Core/AttributedStringBuilder/AttributedStringMarkdownVisitor.swift
+++ b/Sources/ProcessOutCoreUI/Sources/Core/AttributedStringBuilder/AttributedStringMarkdownVisitor.swift
@@ -53,9 +53,8 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
                 let attributedMarker = builder
                     .with { builder in
                         builder.fontFeatures.numberSpacing = .monospaced
-                        builder.text = .plain(marker)
                     }
-                    .build()
+                    .build(string: marker)
                 return [attributedMarker, attributedItem].joined()
             }
             .joined(separator: itemsSeparator)
@@ -79,7 +78,7 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
     }
 
     func visit(text: MarkdownText) -> NSAttributedString {
-        builder.with { $0.text = .plain(text.value) }.build()
+        builder.build(string: text.value)
     }
 
     /// - NOTE: Softbreak is rendered with line break.
@@ -106,7 +105,7 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
             .trimmingCharacters(in: .newlines)
         var builder = builder
         builder.fontSymbolicTraits.formUnion(.traitMonoSpace)
-        return builder.with { $0.text = .plain(code) }.build()
+        return builder.build(string: code)
     }
 
     func visit(thematicBreak: MarkdownThematicBreak) -> NSAttributedString {
@@ -116,7 +115,7 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
     func visit(codeSpan: MarkdownCodeSpan) -> NSAttributedString {
         var builder = builder
         builder.fontSymbolicTraits.formUnion(.traitMonoSpace)
-        return builder.with { $0.text = .plain(codeSpan.code) }.build()
+        return builder.build(string: codeSpan.code)
     }
 
     func visit(link: MarkdownLink) -> NSAttributedString {
@@ -170,8 +169,7 @@ final class AttributedStringMarkdownVisitor: MarkdownVisitor {
         // we are additionally increasing calculated width.
         let marker = textList.marker(forItemNumber: textList.startingItemNumber + itemsCount - 1)
         let indentation = builder
-            .with { $0.text = .plain(marker) }
-            .build()
+            .build(string: marker)
             .size()
             .width + Constants.listMarkerWidthIncrement
         let parentIndentation = builder.tabStops.last?.location ?? 0

--- a/Sources/ProcessOutCoreUI/Sources/DesignSystem/Markdown/POMarkdown.swift
+++ b/Sources/ProcessOutCoreUI/Sources/DesignSystem/Markdown/POMarkdown.swift
@@ -69,17 +69,15 @@ private struct TextViewRepresentable: UIViewRepresentable {
     }
 
     func updateUIView(_ textView: TextView, context: Context) {
-        textView.attributedText = AttributedStringBuilder()
-            .with { builder in
-                builder.typography = style.typography
-                builder.sizeCategory = UIContentSizeCategory(sizeCategory)
-                builder.color = UIColor(style.color)
-                builder.lineBreakMode = .byWordWrapping
-                builder.alignment = NSTextAlignment(multilineTextAlignment)
-                builder.fontFeatures = fontFeatures
-                builder.text = .markdown(string)
-            }
-            .build()
+        let builder = AttributedStringBuilder(
+            typography: style.typography,
+            fontFeatures: fontFeatures,
+            sizeCategory: .init(sizeCategory),
+            color: style.color,
+            alignment: .init(multilineTextAlignment),
+            lineBreakMode: .byWordWrapping
+        )
+        textView.attributedText = builder.build(markdown: string)
         textView.preferredWidth = preferredWidth
     }
 

--- a/Sources/ProcessOutCoreUI/Sources/DesignSystem/TextField/POTextField.swift
+++ b/Sources/ProcessOutCoreUI/Sources/DesignSystem/TextField/POTextField.swift
@@ -153,12 +153,12 @@ private struct TextFieldRepresentable: UIViewRepresentable {
         if textField.text != text {
             textField.text = text
         }
-        let textAttributes = AttributedStringBuilder()
-            .with { builder in
-                builder.typography = style.text.typography
-                builder.sizeCategory = .init(sizeCategory)
-                builder.color = UIColor(style.text.color)
-            }
+        let builder = AttributedStringBuilder(
+            typography: style.text.typography,
+            sizeCategory: .init(sizeCategory),
+            color: style.text.color
+        )
+        let textAttributes = builder
             .buildAttributes()
             .filter { Constants.includedTextAttributes.contains($0.key) }
         textField.defaultTextAttributes = textAttributes

--- a/Sources/ProcessOutCoreUI/Sources/ResourceSymbols/FontResource.swift
+++ b/Sources/ProcessOutCoreUI/Sources/ResourceSymbols/FontResource.swift
@@ -34,8 +34,37 @@ extension FontResource {
     }
 
     static func register() {
-        register(resource: "WorkSans.ttf")
-        register(resource: "WorkSans-Italic.ttf")
+        let registeredFontNames = Set(
+            UIFont.fontNames(forFamilyName: "Work Sans")
+        )
+        let expectedRomanFontNames: Set<String> = [
+            "WorkSans-Regular",
+            "WorkSansRoman-Thin",
+            "WorkSansRoman-ExtraLight",
+            "WorkSansRoman-Light",
+            "WorkSansRoman-Medium",
+            "WorkSansRoman-SemiBold",
+            "WorkSansRoman-Bold",
+            "WorkSansRoman-ExtraBold",
+            "WorkSansRoman-Black"
+        ]
+        if !registeredFontNames.isSuperset(of: expectedRomanFontNames) {
+            register(resource: "WorkSans.ttf")
+        }
+        let expectedItalicFontNames: Set<String> = [
+            "WorkSans-Italic",
+            "WorkSansItalic-Thin",
+            "WorkSansItalic-ExtraLight",
+            "WorkSansItalic-Light",
+            "WorkSansItalic-Medium",
+            "WorkSansItalic-SemiBold",
+            "WorkSansItalic-Bold",
+            "WorkSansItalic-ExtraBold",
+            "WorkSansItalic-Black"
+        ]
+        if !registeredFontNames.isSuperset(of: expectedItalicFontNames) {
+            register(resource: "WorkSans-Italic.ttf")
+        }
     }
 
     // MARK: - Private


### PR DESCRIPTION
## Description
* Fix list marker width calculation
* Simplify `AttributedStringBuilder`
* Ensure fonts are registered by `CoreUI` module only if not present.

## Jira Issue
\-
