### PR TITLE
feat(POM-407): expose invoice invalidation reason

### DIFF
--- a/Example/Example/Sources/UI/Modules/Features/ViewModel/FeaturesViewModel.swift
+++ b/Example/Example/Sources/UI/Modules/Features/ViewModel/FeaturesViewModel.swift
@@ -157,7 +157,9 @@ extension FeaturesViewModel: PODynamicCheckoutDelegate {
         ]
     }
 
-    func dynamicCheckout(newInvoiceFor invoice: POInvoice) async -> POInvoiceRequest? {
+    func dynamicCheckout(
+        newInvoiceFor invoice: POInvoice, invalidationReason: PODynamicCheckoutInvoiceInvalidationReason
+    ) async -> POInvoiceRequest? {
         let request = POInvoiceCreationRequest(
             name: "Example",
             amount: invoice.amount.description,

--- a/Sources/ProcessOutUI/ProcessOutUI.docc/ProcessOutUI.md
+++ b/Sources/ProcessOutUI/ProcessOutUI.docc/ProcessOutUI.md
@@ -74,6 +74,7 @@
 <!--- ``PODynamicCheckoutAlternativePaymentConfiguration``-->
 <!--- ``PODynamicCheckoutDelegate``-->
 <!--- ``PODynamicCheckoutEvent``-->
+<!--- ``PODynamicCheckoutInvoiceInvalidationReason``-->
 
 ### Web Authentication
 

--- a/Sources/ProcessOutUI/Resources/Localizable.xcstrings
+++ b/Sources/ProcessOutUI/Resources/Localizable.xcstrings
@@ -1643,6 +1643,40 @@
         }
       }
     },
+    "dynamic-checkout.error.method-unavailable" : {
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "طريقة الدفع المطلوبة غير متاحة، يرجى تجربة طريقة دفع أخرى."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The requested payment method is not available, please try another payment method."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Le mode de paiement demandé n'est pas disponible, veuillez essayer un autre mode de paiement."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybrana metoda płatności nie jest obsługiwana. Proszę wybierz inną metodę."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O método de pagamento escolhido não está disponível, por favor tente outro método de pagamento."
+          }
+        }
+      }
+    },
     "dynamic-checkout.pay-button" : {
       "localizations" : {
         "ar" : {

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
@@ -30,7 +30,9 @@ public protocol PODynamicCheckoutDelegate: AnyObject {
 
     /// Your implementation could return a request that will be used to fetch new invoice to replace existing one
     /// to be able to recover from normally unrecoverable payment failure.
-    func dynamicCheckout(newInvoiceFor invoice: POInvoice) async -> POInvoiceRequest?
+    func dynamicCheckout(
+        newInvoiceFor invoice: POInvoice, invalidationReason: PODynamicCheckoutInvoiceInvalidationReason
+    ) async -> POInvoiceRequest?
 
     // MARK: - Card Payment
 
@@ -70,7 +72,9 @@ extension PODynamicCheckoutDelegate {
         true
     }
 
-    public func dynamicCheckout(newInvoiceFor invoice: POInvoice) async -> POInvoiceRequest? {
+    public func dynamicCheckout(
+        newInvoiceFor invoice: POInvoice, invalidationReason: PODynamicCheckoutInvoiceInvalidationReason
+    ) async -> POInvoiceRequest? {
         nil
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutInvoiceInvalidationReason.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutInvoiceInvalidationReason.swift
@@ -1,0 +1,18 @@
+//
+//  PODynamicCheckoutInvoiceInvalidationReason.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 12.08.2024.
+//
+
+import ProcessOut
+
+/// Invoice invalidation reason.
+public enum PODynamicCheckoutInvoiceInvalidationReason: Sendable {
+
+    /// User requested different payment method selection that requires new invoice.
+    case paymentMethodChanged
+
+    /// Selected method failed and payment can't be continued with current invoice.
+    case failure(POFailure)
+}

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
@@ -162,10 +162,7 @@ final class DynamicCheckoutDefaultInteractor:
         invoice: POInvoice, errorDescription: String? = nil, sendEvents: Bool
     ) {
         guard invoice.paymentMethods?.isEmpty == false else {
-            let failure = POFailure(
-                message: "Unable to start dynamic checkout without payment methods.",
-                code: .generic(.mobile)
-            )
+            let failure = POFailure(message: "Payment methods are not available.", code: .generic(.mobile))
             setFailureStateUnchecked(error: failure)
             return
         }

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
@@ -595,8 +595,9 @@ final class DynamicCheckoutDefaultInteractor:
                 let reason: PODynamicCheckoutInvoiceInvalidationReason = failure.code == .cancelled
                     ? .paymentMethodChanged
                     : .failure(failure)
-                // swiftlint:disable:next line_length
-                guard let request = await delegate?.dynamicCheckout(newInvoiceFor: currentState.snapshot.invoice, invalidationReason: reason) else {
+                guard let request = await delegate?.dynamicCheckout(
+                    newInvoiceFor: currentState.snapshot.invoice, invalidationReason: reason
+                ) else {
                     throw failure
                 }
                 let newInvoice = try await invoicesService.invoice(request: request)

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
@@ -587,7 +587,11 @@ final class DynamicCheckoutDefaultInteractor:
         state = .recovering(recoveringState)
         if shouldCreateNewInvoice(toRecoverFrom: failure, in: currentState) {
             do {
-                guard let request = await delegate?.dynamicCheckout(newInvoiceFor: currentState.snapshot.invoice) else {
+                let reason: PODynamicCheckoutInvoiceInvalidationReason = failure.code == .cancelled
+                    ? .paymentMethodChanged
+                    : .failure(failure)
+                // swiftlint:disable:next line_length
+                guard let request = await delegate?.dynamicCheckout(newInvoiceFor: currentState.snapshot.invoice, invalidationReason: reason) else {
                     throw failure
                 }
                 let newInvoice = try await invoicesService.invoice(request: request)

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckout/DynamicCheckoutDefaultInteractor.swift
@@ -161,6 +161,14 @@ final class DynamicCheckoutDefaultInteractor:
     private func setStartedStateUnchecked(
         invoice: POInvoice, errorDescription: String? = nil, sendEvents: Bool
     ) {
+        guard invoice.paymentMethods?.isEmpty == false else {
+            let failure = POFailure(
+                message: "Unable to start dynamic checkout without payment methods.",
+                code: .generic(.mobile)
+            )
+            setFailureStateUnchecked(error: failure)
+            return
+        }
         let pkPaymentRequests = pkPaymentRequests(invoice: invoice)
         var expressMethodIds: [String] = [], regularMethodIds: [String] = []
         let paymentMethods = partitioned(

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Symbols/StringResource+DynamicCheckout.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Symbols/StringResource+DynamicCheckout.swift
@@ -38,6 +38,9 @@ extension POStringResource {
 
             /// Indicates that implementation is unable to process payment.
             static let generic = POStringResource("dynamic-checkout.error.generic", comment: "")
+
+            /// Indicates that selected payment method is no longer available.
+            static let methodUnavailable = POStringResource("dynamic-checkout.error.method-unavailable", comment: "")
         }
 
         enum Warning {


### PR DESCRIPTION
## Description
* Expose invoice invalidation reason during DC
* Fail dynamic checkout when there are no payment methods in invoice
* Display error if payment method becomes unavailable during error recovery (see video)

https://github.com/user-attachments/assets/e1dce1d5-0789-49de-b6f3-bbc3d13162f7

## Jira Issue
https://checkout.atlassian.net/browse/POM-400
