### PR TITLE
fix(POM-423): UI modules cancellation

### DIFF
--- a/Example/Example/Sources/UI/Modules/AlternativePayments/ViewModel/AlternativePaymentsViewModel.swift
+++ b/Example/Example/Sources/UI/Modules/AlternativePayments/ViewModel/AlternativePaymentsViewModel.swift
@@ -165,7 +165,9 @@ final class AlternativePaymentsViewModel: ObservableObject {
             let configuration = PONativeAlternativePaymentConfiguration(
                 invoiceId: invoice.id,
                 gatewayConfigurationId: gatewayConfigurationId,
-                secondaryAction: .cancel(),
+                secondaryAction: .cancel(
+                    confirmation: .init()
+                ),
                 paymentConfirmation: .init(
                     showProgressIndicatorAfter: 5,
                     confirmButton: .init(),

--- a/Sources/ProcessOut/Sources/Generated/Fonts+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Fonts+Generated.swift
@@ -44,7 +44,7 @@ internal enum FontFamily {
   }
   internal static let allCustomFonts: [FontConvertible] = [WorkSans.all].flatMap { $0 }
   internal static func registerAllCustomFonts() {
-    allCustomFonts.forEach { $0.register() }
+    allCustomFonts.forEach { $0.registerIfNeeded() }
   }
 }
 // swiftlint:enable identifier_name line_length type_body_length

--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -80,7 +80,7 @@ extension POCardsService {
     /// Allows to retrieve card issuer information based on IIN.
     /// 
     /// - Parameters:
-    ///   - iin: Card issuer identification number. Corresponds to the first 6 or 8 digits of the main card number.
+    ///   - iin: Card issuer identification number. Length should be at least 6 otherwise error is thrown.
     @discardableResult
     public func issuerInformation(
         iin: String,

--- a/Sources/ProcessOut/Sources/Services/Cards/POCardsService.swift
+++ b/Sources/ProcessOut/Sources/Services/Cards/POCardsService.swift
@@ -14,7 +14,7 @@ public protocol POCardsService: POService { // sourcery: AutoCompletion
     /// Allows to retrieve card issuer information based on IIN.
     ///
     /// - Parameters:
-    ///   - iin: Card issuer identification number. Corresponds to the first 6 or 8 digits of the main card number.
+    ///   - iin: Card issuer identification number. Length should be at least 6 otherwise error is thrown.
     func issuerInformation(iin: String) async throws -> POCardIssuerInformation
 
     /// Tokenizes a card. You can use the card for a single payment by creating a card token with it. If you want

--- a/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/Interactor/PONativeAlternativePaymentMethodDelegate.swift
+++ b/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/Interactor/PONativeAlternativePaymentMethodDelegate.swift
@@ -19,3 +19,19 @@ public protocol PONativeAlternativePaymentMethodDelegate: AnyObject {
         for parameters: [PONativeAlternativePaymentMethodParameter], completion: @escaping ([String: String]) -> Void
     )
 }
+
+extension PONativeAlternativePaymentMethodDelegate {
+
+    /// Method provides an ability to supply default values for given parameters. It is not mandatory
+    /// to provide defaults for all parameters.
+    ///
+    /// - Returns: Dictionary where key is a parameter key, and value is desired default.
+    @_spi(PO)
+    public func nativeAlternativePayment(
+        defaultValuesFor parameters: [PONativeAlternativePaymentMethodParameter]
+    ) async -> [String: String] {
+        await withCheckedContinuation { continuation in
+            nativeAlternativePaymentMethodDefaultValues(for: parameters) { continuation.resume(returning: $0) }
+        }
+    }
+}

--- a/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/Interactor/PONativeAlternativePaymentMethodDelegate.swift
+++ b/Sources/ProcessOut/Sources/UI/Modules/NativeAlternativePaymentMethod/Interactor/PONativeAlternativePaymentMethodDelegate.swift
@@ -27,6 +27,7 @@ extension PONativeAlternativePaymentMethodDelegate {
     ///
     /// - Returns: Dictionary where key is a parameter key, and value is desired default.
     @_spi(PO)
+    @MainActor
     public func nativeAlternativePayment(
         defaultValuesFor parameters: [PONativeAlternativePaymentMethodParameter]
     ) async -> [String: String] {

--- a/Sources/ProcessOutUI/Sources/Core/Interactor/BaseInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Core/Interactor/BaseInteractor.swift
@@ -23,7 +23,6 @@ class BaseInteractor<State>: Interactor {
     var didChange: (() -> Void)?
     var willChange: ((State) -> Void)?
 
-    @MainActor
     func start() {
         // Does nothing
     }

--- a/Sources/ProcessOutUI/Sources/Core/Interactor/Interactor.swift
+++ b/Sources/ProcessOutUI/Sources/Core/Interactor/Interactor.swift
@@ -5,6 +5,7 @@
 //  Created by Andrii Vysotskyi on 19.10.2023.
 //
 
+@MainActor
 protocol Interactor<State>: AnyObject {
 
     associatedtype State

--- a/Sources/ProcessOutUI/Sources/Core/ViewModel/AnyViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Core/ViewModel/AnyViewModel.swift
@@ -27,6 +27,10 @@ final class AnyViewModel<State>: ViewModel {
         base.start()
     }
 
+    func stop() {
+        base.stop()
+    }
+
     var state: State {
         get { base.state }
         set { base.state = newValue }
@@ -50,6 +54,10 @@ private class ViewModelBox<T>: AnyViewModelBase<T.State> where T: ViewModel {
         base.start()
     }
 
+    override func stop() {
+        base.stop()
+    }
+
     override var state: T.State {
         get { base.state }
         set { base.state = newValue }
@@ -61,6 +69,10 @@ private class ViewModelBox<T>: AnyViewModelBase<T.State> where T: ViewModel {
 private class AnyViewModelBase<State>: ViewModel {
 
     func start() {
+        fatalError("Not implemented")
+    }
+
+    func stop() {
         fatalError("Not implemented")
     }
 

--- a/Sources/ProcessOutUI/Sources/Core/ViewModel/ViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Core/ViewModel/ViewModel.swift
@@ -7,6 +7,7 @@
 
 import Combine
 
+@MainActor
 protocol ViewModel<State>: ObservableObject {
 
     associatedtype State

--- a/Sources/ProcessOutUI/Sources/Core/ViewModel/ViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Core/ViewModel/ViewModel.swift
@@ -16,4 +16,14 @@ protocol ViewModel<State>: ObservableObject {
 
     /// Starts view model.
     func start()
+
+    /// Cancels view model.
+    func stop()
+}
+
+extension ViewModel {
+
+    func stop() {
+        // Ignored
+    }
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractor.swift
@@ -7,6 +7,7 @@
 
 import ProcessOut
 
+@MainActor
 protocol CardTokenizationInteractor: Interactor<CardTokenizationInteractorState> {
 
     /// Delegate.

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Combine
 import ProcessOut
 
 enum CardTokenizationInteractorState {
@@ -46,8 +45,8 @@ enum CardTokenizationInteractorState {
         /// Started state snapshot.
         let snapshot: Started
 
-        /// Tokenization cancellable.
-        let cancellable: AnyCancellable
+        /// Tokenization task.
+        let task: Task<Void, Never>
     }
 
     struct AddressParameters {

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -241,7 +241,7 @@ final class DefaultCardTokenizationInteractor:
 
     private func setFailureState(failure: POFailure) {
         if state.isSink {
-            logger.debug("Already in a sink state, ignoring attempt to set failure state.")
+            logger.debug("Already in a sink state, ignoring attempt to set failure state with: \(failure).")
         } else {
             state = .failure(failure)
             logger.info("Did fail to tokenize/process card \(failure)")

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -142,13 +142,8 @@ final class DefaultCardTokenizationInteractor:
     }
 
     override func cancel() {
-        switch state {
-        case .idle, .started:
-            break
-        case .tokenizing(let currentState):
+        if case .tokenizing(let currentState) = state {
             currentState.cancellable.cancel()
-        case .tokenized, .failure:
-            logger.debug("Unable to cancel in sink state, ignored.")
         }
         setFailureState(failure: POFailure(code: .cancelled))
     }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/View/POCardTokenizationView.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/View/POCardTokenizationView.swift
@@ -31,6 +31,7 @@ public struct POCardTokenizationView: View {
             style.backgroundColor.ignoresSafeArea()
         }
         .onAppear(perform: viewModel.start)
+        .onDisappear(perform: viewModel.stop)
     }
 
     // MARK: - Private Properties

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -28,6 +28,10 @@ final class DefaultCardTokenizationViewModel: ViewModel {
         $state.performWithoutAnimation(interactor.start)
     }
 
+    func stop() {
+        interactor.cancel()
+    }
+
     // MARK: - Private Nested Types
 
     private typealias InteractorState = CardTokenizationInteractorState
@@ -68,11 +72,11 @@ final class DefaultCardTokenizationViewModel: ViewModel {
         switch interactor.state {
         case .idle:
             state = .idle
-        case .started(let startedState):
-            let newState = convertToState(startedState: startedState, isSubmitting: false)
+        case .started(let currentState):
+            let newState = convertToState(startedState: currentState, isSubmitting: false)
             self.state = newState
-        case .tokenizing(let startedState):
-            let newState = convertToState(startedState: startedState, isSubmitting: true)
+        case .tokenizing(let currentState):
+            let newState = convertToState(startedState: currentState.snapshot, isSubmitting: true)
             self.state = newState
         default:
             break

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractor.swift
@@ -7,6 +7,7 @@
 
 import ProcessOut
 
+@MainActor
 protocol CardUpdateInteractor: Interactor<CardUpdateInteractorState> {
 
     /// Updates CVC value.

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractor.swift
@@ -18,6 +18,6 @@ protocol CardUpdateInteractor: Interactor<CardUpdateInteractorState> {
     /// Attempts to update card with new CVC.
     func submit()
 
-    /// Cancells update if possible.
+    /// Cancels update if possible.
     func cancel()
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/CardUpdateInteractorState.swift
@@ -8,12 +8,18 @@
 import Foundation
 import ProcessOut
 
-enum CardUpdateInteractorState: Equatable {
+enum CardUpdateInteractorState {
+
+    struct Starting {
+
+        /// Start task.
+        let task: Task<Void, Never>
+    }
 
     struct Started: Equatable {
 
         /// Masked card number.
-        var cardNumber: String?
+        let cardNumber: String?
 
         /// Scheme of the card.
         var scheme: POCardScheme?
@@ -28,7 +34,7 @@ enum CardUpdateInteractorState: Equatable {
         var cvc: String = ""
 
         /// Formatter that should be used to format CVC.
-        var formatter: Formatter?
+        let formatter: Formatter
 
         /// Indicates whether parameters are valid.
         /// - NOTE: CVC is the only parameter that could be invalid at a moment.
@@ -38,17 +44,39 @@ enum CardUpdateInteractorState: Equatable {
         var recentErrorMessage: String?
     }
 
+    struct Updating {
+
+        /// Started state snapshot.
+        let snapshot: Started
+
+        /// Update task.
+        let task: Task<Void, Never>
+    }
+
     case idle
 
     /// Interactor is currently starting.
-    case starting
+    case starting(Starting)
 
     /// Interactor has started and is ready.
     case started(Started)
 
     /// Card information is currently being updated.
-    case updating(snapshot: Started)
+    case updating(Updating)
 
     /// Card update has finished. This is a sink state.
     case completed
+}
+
+extension CardUpdateInteractorState {
+
+    /// Boolean variable that indicates whether the current state is a sink state.
+    ///
+    /// A sink state is a special kind of state where, once entered, no other state transitions are possible.
+    var isSink: Bool {
+        if case .completed = self {
+            return true
+        }
+        return false
+    }
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
@@ -32,15 +32,17 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         }
         logger.debug("Will start card update")
         delegate?.cardUpdateDidEmitEvent(.willStart)
-        if let cardInfo = configuration.cardInformation {
-            setStartedStateUnchecked(cardInfo: cardInfo)
-        } else {
-            state = .starting
-            Task {
-                let cardInfo = await delegate?.cardInformation(cardId: configuration.cardId)
-                setStartedStateUnchecked(cardInfo: cardInfo)
+        let task = Task { @MainActor in
+            logger.debug("Did start card update")
+            var cardInfo = configuration.cardInformation
+            if cardInfo == nil {
+                cardInfo = await delegate?.cardInformation(cardId: configuration.cardId)
             }
+            let issuerInformation = await self.issuerInformation(cardInfo: cardInfo)
+            setStartedState(cardInfo: cardInfo, issuerInformation: issuerInformation)
         }
+        let startingState = State.Starting(task: task)
+        state = .starting(startingState)
     }
 
     func update(cvc: String) {
@@ -48,7 +50,7 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
             return
         }
         logger.debug("Will change CVC to '\(cvc)'")
-        let formatted = cardSecurityCodeFormatter.string(from: cvc)
+        let formatted = startedState.formatter.string(for: cvc) ?? ""
         guard startedState.cvc != formatted else {
             logger.debug("Ignoring same CVC value \(formatted)")
             return
@@ -67,9 +69,7 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         let supportedSchemes = [startedState.scheme, startedState.coScheme].compactMap { $0 }
         logger.debug("Will change card scheme to \(scheme)")
         guard supportedSchemes.contains(scheme) else {
-            logger.info(
-                "Aborting attempt to select unknown '\(scheme)' scheme, supported schemes are: \(supportedSchemes)"
-            )
+            logger.info("Unable to select unknown '\(scheme)' scheme, supported values: \(supportedSchemes)")
             return
         }
         startedState.preferredScheme = scheme
@@ -77,109 +77,93 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         delegate?.cardUpdateDidEmitEvent(.parametersChanged)
     }
 
-    @MainActor
     func submit() {
-        guard case .started(let startedState) = state else {
+        guard case .started(let currentState) = state else {
+            logger.debug("Ignoring submission attempt from unsupported state: \(state).")
             return
         }
-        guard startedState.areParametersValid else {
+        guard currentState.areParametersValid else {
             logger.debug("Ignoring attempt to submit invalid parameters.")
             return
         }
-        logger.debug("Will submit card information")
+        logger.debug("Will submit card information.")
         delegate?.cardUpdateDidEmitEvent(.willUpdateCard)
-        state = .updating(snapshot: startedState)
-        Task {
+        let task = Task { @MainActor in
             do {
                 let request = POCardUpdateRequest(
                     cardId: configuration.cardId,
-                    cvc: startedState.cvc,
-                    preferredScheme: startedState.preferredScheme?.rawValue
+                    cvc: currentState.cvc,
+                    preferredScheme: currentState.preferredScheme?.rawValue
                 )
                 setCompletedState(card: try await cardsService.updateCard(request: request))
             } catch {
-                recoverUpdate(from: error)
+                attemptRecoverUpdateError(error)
             }
         }
+        state = .updating(State.Updating(snapshot: currentState, task: task))
     }
 
     override func cancel() {
-        guard case .started = state else {
-            return
+        switch state {
+        case .starting(let currentState):
+            currentState.task.cancel()
+        case .updating(let currentState):
+            currentState.task.cancel()
+        default:
+            break // Ignored
         }
-        let failure = POFailure(code: .cancelled)
-        setFailureStateUnchecked(failure: failure)
+        setFailureState(failure: POFailure(code: .cancelled))
     }
 
     // MARK: - Private Properties
-
-    private weak var delegate: POCardUpdateDelegate?
 
     private let cardsService: POCardsService
     private let logger: POLogger
     private let configuration: POCardUpdateConfiguration
     private let completion: (Result<POCard, POFailure>) -> Void
 
-    private lazy var cardSecurityCodeFormatter = CardSecurityCodeFormatter()
+    private weak var delegate: POCardUpdateDelegate?
 
     // MARK: - Started State
 
-    @MainActor
-    private func setStartedStateUnchecked(cardInfo: POCardUpdateInformation?) {
-        cardSecurityCodeFormatter.scheme = cardInfo?.$scheme.typed
+    private func setStartedState(cardInfo: POCardUpdateInformation?, issuerInformation: POCardIssuerInformation?) {
+        switch state {
+        case .idle, .starting:
+            break
+        default:
+            logger.debug("Ignoring attempt to set started state from unsupported state: \(state)")
+            return
+        }
+        let formatter = CardSecurityCodeFormatter()
+        formatter.scheme = issuerInformation?.$scheme.typed
         let startedState = State.Started(
             cardNumber: cardInfo?.maskedNumber,
-            scheme: cardInfo?.$scheme.typed,
-            coScheme: cardInfo?.$coScheme.typed,
-            preferredScheme: preferredScheme(cardInfo: cardInfo),
-            formatter: cardSecurityCodeFormatter
+            scheme: issuerInformation?.$scheme.typed,
+            coScheme: issuerInformation?.$coScheme.typed,
+            preferredScheme: preferredScheme(cardInfo: cardInfo, issuerInformation: issuerInformation),
+            formatter: formatter
         )
         self.state = .started(startedState)
         delegate?.cardUpdateDidEmitEvent(.didStart)
-        logger.debug("Did start card update")
-        Task {
-            await updateSchemeIfNeeded(cardInfo: cardInfo)
-        }
     }
 
     // MARK: - Scheme Update
 
-    @MainActor
-    private func updateSchemeIfNeeded(cardInfo: POCardUpdateInformation?) async {
-        guard cardInfo?.scheme == nil || cardInfo?.coScheme == nil else {
-            logger.debug("Needed schemes information is already set, ignored")
-            return
+    private func issuerInformation(cardInfo: POCardUpdateInformation?) async -> POCardIssuerInformation? {
+        if let scheme = cardInfo?.$scheme.typed {
+            logger.debug("Needed schemes information is already set, won't resolve.")
+            return POCardIssuerInformation(scheme: scheme, coScheme: cardInfo?.$coScheme.typed)
         }
         guard let iin = cardInfo?.iin ?? cardInfo?.maskedNumber.flatMap(issuerIdentificationNumber) else {
             logger.info("Unable to resolve scheme, IIN is not available")
-            return
+            return nil
         }
         do {
-            let issuerInformation = try await cardsService.issuerInformation(iin: iin)
-            logger.info("Did resolve issuer info: \(issuerInformation)")
-            switch state {
-            case .started(var startedState):
-                update(state: &startedState, with: issuerInformation)
-                state = .started(startedState)
-            case .updating(var startedState):
-                update(state: &startedState, with: issuerInformation)
-                state = .updating(snapshot: startedState)
-            default:
-                logger.debug("Unsupported state, resolved scheme info is ignored")
-                return
-            }
+            return try await cardsService.issuerInformation(iin: iin)
         } catch {
-            logger.info("Did fail to resolve scheme: \(error)")
+            logger.info("Did fail to resolve issuer information: \(error)")
         }
-    }
-
-    /// - NOTE: Method updates interactor's CSC formatter as well.
-    private func update(state: inout State.Started, with issuerInformation: POCardIssuerInformation) {
-        cardSecurityCodeFormatter.scheme = issuerInformation.$scheme.typed
-        state.scheme = issuerInformation.$scheme.typed
-        state.coScheme = issuerInformation.$coScheme.typed
-        state.preferredScheme = state.preferredScheme ?? preferredScheme(issuerInformation: issuerInformation)
-        state.cvc = cardSecurityCodeFormatter.string(from: state.cvc)
+        return nil
     }
 
     private func issuerIdentificationNumber(maskedNumber: String) -> String? {
@@ -197,68 +181,6 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         return nil
     }
 
-    // MARK: - Failure Recovery
-
-    private func recoverUpdate(from error: Error) {
-        if let failure = error as? POFailure {
-            recoverUpdate(from: failure)
-            return
-        }
-        let failure = POFailure(code: .generic(.mobile), underlyingError: error)
-        recoverUpdate(from: failure)
-    }
-
-    private func recoverUpdate(from failure: POFailure) {
-        guard case .updating(var startedState) = state else {
-            assertionFailure("Unsupported state")
-            return
-        }
-        let shouldContinue = delegate?.shouldContinueUpdate(after: failure) ?? true
-        guard shouldContinue else {
-            setFailureStateUnchecked(failure: failure)
-            return
-        }
-        var errorMessage: POStringResource
-        switch failure.code {
-        case .generic(.requestInvalidCard),
-             .generic(.cardInvalid),
-             .generic(.cardBadTrackData),
-             .generic(.cardMissingCvc),
-             .generic(.cardInvalidCvc),
-             .generic(.cardFailedCvc),
-             .generic(.cardFailedCvcAndAvs):
-            startedState.areParametersValid = false
-            errorMessage = .CardUpdate.Error.cvc
-        default:
-            startedState.areParametersValid = true
-            errorMessage = .CardUpdate.Error.generic
-        }
-        // todo(andrii-vysotskyi): remove hardcoded message when backend is updated with localized values
-        startedState.recentErrorMessage = String(resource: errorMessage)
-        state = .started(startedState)
-        logger.debug("Did recover started state after failure: \(failure)")
-    }
-
-    private func setFailureStateUnchecked(failure: POFailure) {
-        logger.info("Did fail to update card \(failure)")
-        state = .completed
-        completion(.failure(failure))
-    }
-
-    // MARK: - Completed State
-
-    private func setCompletedState(card: POCard) {
-        guard case .updating = state else {
-            return
-        }
-        logger.info("Did update card")
-        state = .completed
-        delegate?.cardUpdateDidEmitEvent(.didComplete)
-        completion(.success(card))
-    }
-
-    // MARK: - Preferred Scheme
-
     private func preferredScheme(
         cardInfo: POCardUpdateInformation? = nil,
         issuerInformation: POCardIssuerInformation? = nil
@@ -269,6 +191,73 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
         guard configuration.isSchemeSelectionAllowed else {
             return nil
         }
-        return cardInfo?.$scheme.typed ?? issuerInformation?.$scheme.typed
+        return issuerInformation?.$scheme.typed
+    }
+
+    // MARK: - Failure Recovery
+
+    private func attemptRecoverUpdateError(_ error: Error) {
+        guard case .updating(let currentState) = state else {
+            logger.debug("Unable to recover update error from unsupported state: \(state).")
+            return
+        }
+        let failure = (error as? POFailure) ?? .init(code: .generic(.mobile), underlyingError: error)
+        if case .cancelled = failure.code {
+            setFailureState(failure: failure)
+        } else if delegate?.shouldContinueUpdate(after: failure) != false {
+            var newState = currentState.snapshot
+            newState.recentErrorMessage = errorMessage(for: failure, areParametersValid: &newState.areParametersValid)
+            state = .started(newState)
+            logger.debug("Did recover started state after failure: \(failure).")
+        } else {
+            setFailureState(failure: failure)
+        }
+    }
+
+    private func errorMessage(for failure: POFailure, areParametersValid: inout Bool) -> String? {
+        // todo(andrii-vysotskyi): remove hardcoded message when backend is updated with localized values
+        var errorMessage: POStringResource
+        switch failure.code {
+        case .generic(.requestInvalidCard),
+             .generic(.cardInvalid),
+             .generic(.cardBadTrackData),
+             .generic(.cardMissingCvc),
+             .generic(.cardInvalidCvc),
+             .generic(.cardFailedCvc),
+             .generic(.cardFailedCvcAndAvs):
+            areParametersValid = false
+            errorMessage = .CardUpdate.Error.cvc
+        case .cancelled:
+            return nil
+        default:
+            areParametersValid = true
+            errorMessage = .CardUpdate.Error.generic
+        }
+        return String(resource: errorMessage)
+    }
+
+    // MARK: - Failure State
+
+    private func setFailureState(failure: POFailure) {
+        if state.isSink {
+            logger.debug("Already in a sink state, ignoring attempt to set failure state.")
+        } else {
+            state = .completed
+            logger.info("Did fail to update card \(failure)")
+            completion(.failure(failure))
+        }
+    }
+
+    // MARK: - Completed State
+
+    private func setCompletedState(card: POCard) {
+        if state.isSink {
+            logger.debug("Unable to complete with card: \(card), already in a sink state.")
+        } else {
+            logger.info("Did update card")
+            state = .completed
+            delegate?.cardUpdateDidEmitEvent(.didComplete)
+            completion(.success(card))
+        }
     }
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
@@ -149,6 +149,7 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
 
     // MARK: - Scheme Update
 
+    @MainActor
     private func issuerInformation(cardInfo: POCardUpdateInformation?) async -> POCardIssuerInformation? {
         if let scheme = cardInfo?.$scheme.typed {
             logger.debug("Needed schemes information is already set, won't resolve.")

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
@@ -241,7 +241,7 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
 
     private func setFailureState(failure: POFailure) {
         if state.isSink {
-            logger.debug("Already in a sink state, ignoring attempt to set failure state.")
+            logger.debug("Already in a sink state, ignoring attempt to set failure state with: \(failure).")
         } else {
             state = .completed
             logger.info("Did fail to update card \(failure)")

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/Interactor/DefaultCardUpdateInteractor.swift
@@ -149,7 +149,6 @@ final class DefaultCardUpdateInteractor: BaseInteractor<CardUpdateInteractorStat
 
     // MARK: - Scheme Update
 
-    @MainActor
     private func issuerInformation(cardInfo: POCardUpdateInformation?) async -> POCardIssuerInformation? {
         if let scheme = cardInfo?.$scheme.typed {
             logger.debug("Needed schemes information is already set, won't resolve.")

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/View/POCardUpdateView.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/View/POCardUpdateView.swift
@@ -47,6 +47,7 @@ public struct POCardUpdateView: View {
             style.backgroundColor.ignoresSafeArea()
         }
         .onAppear(perform: viewModel.start)
+        .onDisappear(perform: viewModel.stop)
     }
 
     // MARK: - Private Properties

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/AnyCardUpdateViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/AnyCardUpdateViewModel.swift
@@ -42,6 +42,10 @@ final class AnyCardUpdateViewModel: CardUpdateViewModel {
         base.start()
     }
 
+    func stop() {
+        base.stop()
+    }
+
     // MARK: - Private Properties
 
     private var cancellable: AnyCancellable?

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/CardUpdateViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/CardUpdateViewModel.swift
@@ -8,6 +8,7 @@
 import Combine
 @_spi(PO) import ProcessOutCoreUI
 
+@MainActor
 protocol CardUpdateViewModel: ObservableObject {
 
     /// Screen title.

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/CardUpdateViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/CardUpdateViewModel.swift
@@ -24,4 +24,7 @@ protocol CardUpdateViewModel: ObservableObject {
 
     /// Starts view model.
     func start()
+
+    /// Stops view model.
+    func stop()
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/DefaultCardUpdateViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardUpdate/ViewModel/DefaultCardUpdateViewModel.swift
@@ -39,6 +39,10 @@ final class DefaultCardUpdateViewModel: CardUpdateViewModel {
         interactor.start()
     }
 
+    func stop() {
+        interactor.cancel()
+    }
+
     // MARK: - Private Nested Types
 
     private typealias InteractorState = CardUpdateInteractorState
@@ -84,13 +88,13 @@ final class DefaultCardUpdateViewModel: CardUpdateViewModel {
             ]
             updateActionsWithStartingState()
             focusedItemId = nil
-        case .started(let state):
-            updateSections(with: state)
-            updateActions(with: state)
+        case .started(let currentState):
+            updateSections(with: currentState)
+            updateActions(with: currentState)
             focusedItemId = ItemId.cvc
-        case .updating(let state):
-            updateSections(with: state)
-            updateActions(with: state, isSubmitting: true)
+        case .updating(let currentState):
+            updateSections(with: currentState.snapshot)
+            updateActions(with: currentState.snapshot, isSubmitting: true)
             focusedItemId = nil
         }
     }

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -412,7 +412,7 @@ final class DynamicCheckoutDefaultInteractor:
         switch state {
         case .idle:
             break // Ignored
-        case .started(let startedState):
+        case .started:
             currentState.isCancellable = currentState.snapshot.isCancellable
             self.state = .paymentProcessing(currentState)
         case .tokenizing:

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -501,7 +501,7 @@ final class DynamicCheckoutDefaultInteractor:
             currentState.isAwaitingNativeAlternativePaymentCapture = false
             self.state = .paymentProcessing(currentState)
         case .submitting(let submittingState):
-            currentState.isCancellable = submittingState.isCancellable
+            currentState.isCancellable = submittingState.snapshot.isCancellable
             currentState.isReady = true
             currentState.isAwaitingNativeAlternativePaymentCapture = false
             self.state = .paymentProcessing(currentState)

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -134,7 +134,6 @@ final class DynamicCheckoutDefaultInteractor:
 
     // MARK: - Starting State
 
-    @MainActor
     private func continueStartUnchecked() async {
         do {
             let invoice = try await invoicesService.invoice(request: configuration.invoiceRequest)
@@ -577,7 +576,6 @@ final class DynamicCheckoutDefaultInteractor:
         return delegate.dynamicCheckout(shouldContinueAfter: failure)
     }
 
-    @MainActor
     private func continuePaymentProcessingRecovery(after failure: POFailure) async {
         guard case .paymentProcessing(let currentState) = state else {
             assertionFailure("Error could be recovered only when processing payment.")
@@ -739,7 +737,6 @@ final class DynamicCheckoutDefaultInteractor:
         }
     }
 
-    @MainActor
     private func authorizeInvoice(source: String, saveSource: Bool, startedState: State.Started) async throws {
         guard let delegate else {
             throw POFailure(message: "Delegate must be set to authorize invoice.", code: .generic(.mobile))
@@ -763,7 +760,6 @@ extension DynamicCheckoutDefaultInteractor: POCardTokenizationDelegate {
         delegate?.dynamicCheckout(didEmitCardTokenizationEvent: event)
     }
 
-    @MainActor
     func cardTokenization(didTokenizeCard card: POCard, shouldSaveCard save: Bool) async throws {
         invalidateInvoiceIfPossible()
         guard case .paymentProcessing(let currentState) = state else {

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutInteractor.swift
@@ -5,6 +5,7 @@
 //  Created by Andrii Vysotskyi on 05.03.2024.
 //
 
+@MainActor
 protocol DynamicCheckoutInteractor: Interactor<DynamicCheckoutInteractorState> {
 
     /// Configuration.

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Utils/ChildProvider/DynamicCheckoutInteractorChildProvider.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Utils/ChildProvider/DynamicCheckoutInteractorChildProvider.swift
@@ -9,6 +9,7 @@
 
 /// - NOTE: Your implementation should expect that instances created
 /// by provider are going to be different every time you call a method.
+@MainActor
 protocol DynamicCheckoutInteractorChildProvider {
 
     /// Creates and returns card tokenization interactor.

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
@@ -39,51 +39,112 @@ final class NativeAlternativePaymentDefaultInteractor:
         guard case .idle = state else {
             return
         }
-        logger.info("Starting native alternative payment")
+        logger.info("Starting native alternative payment.")
         send(event: .willStart)
-        setStateUnchecked(.starting)
-        Task {
-            await continueStartUnchecked()
+        let task = Task { @MainActor in
+            do {
+                let request = PONativeAlternativePaymentMethodTransactionDetailsRequest(
+                    invoiceId: configuration.invoiceId,
+                    gatewayConfigurationId: configuration.gatewayConfigurationId
+                )
+                let transactionDetails = try await invoicesService
+                    .nativeAlternativePaymentMethodTransactionDetails(request: request)
+                switch transactionDetails.state {
+                case .customerInput, nil:
+                    await setStartedState(transactionDetails: transactionDetails)
+                case .pendingCapture:
+                    await setAwaitingCaptureState(
+                        with: transactionDetails.parameterValues, gateway: transactionDetails.gateway
+                    )
+                case .captured:
+                    let paymentProvider = await paymentProvider(
+                        with: transactionDetails.parameterValues, gateway: transactionDetails.gateway
+                    )
+                    await setCapturedState(paymentProvider: paymentProvider)
+                case .failed:
+                    fallthrough // swiftlint:disable:this fallthrough
+                @unknown default:
+                    throw POFailure(code: .generic(.mobile))
+                }
+            } catch {
+                setFailureState(error: error)
+            }
         }
+        state = .starting(.init(task: task))
     }
 
     func updateValue(_ value: String?, for key: String) {
-        guard case var .started(startedState) = state else {
-            logger.debug("Unable to update value in unsupported state: \(state)")
+        guard case var .started(newState) = state else {
+            logger.debug("Unable to update value in unsupported state: \(state).")
             return
         }
-        // swiftlint:disable:next line_length
-        guard let element = startedState.parameters.enumerated().first(where: { $0.element.specification.key == key }) else {
-            logger.info("No value to update for key \(key)")
+        let parameter = newState.parameters
+            .enumerated()
+            .first(where: { $0.element.specification.key == key })
+        guard let parameter else {
+            logger.info("No value to update for key \(key).")
             return
         }
-        var parameter = element.1
-        let formattedValue = parameter.formatter?.string(for: value ?? "") ?? value
-        guard parameter.value != formattedValue else {
-            logger.debug("Ignored the same value for key: \(key)")
+        let formattedValue = parameter.element.formatter?.string(for: value ?? "") ?? value
+        guard parameter.element.value != formattedValue else {
+            logger.debug("Ignored the same value for key: \(key).")
             return
         }
-        parameter.value = formattedValue
-        parameter.recentErrorMessage = nil
-        startedState.parameters[element.0] = parameter
-        setStateUnchecked(.started(startedState))
-        didUpdate(parameter: parameter, to: formattedValue ?? "")
+        var updatedParameter = parameter.element
+        updatedParameter.value = formattedValue
+        updatedParameter.recentErrorMessage = nil
+        newState.parameters[parameter.offset] = updatedParameter
+        state = .started(newState)
+        didUpdate(parameter: parameter.element, to: formattedValue ?? "")
     }
 
     func submit() {
-        guard case let .started(startedState) = state, startedState.areParametersValid else {
+        guard case let .started(currentState) = state else {
+            logger.debug("Ignoring attempt to submit parameters in unsupported state: \(state).")
             return
         }
-        willSubmit(parameters: startedState.parameters)
-        do {
-            let values = try validatedValues(for: startedState.parameters)
-            setStateUnchecked(.submitting(snapshot: startedState))
-            Task {
-                await continueSubmissionUnchecked(startedState: startedState, values: values)
-            }
-        } catch {
-            restoreStartedStateAfterSubmissionFailureIfPossible(error, replaceErrorMessages: false)
+        guard currentState.areParametersValid else {
+            logger.debug("Ignoring attempt to submit invalid parameters.")
+            return
         }
+        willSubmit(parameters: currentState.parameters)
+        let task = Task { @MainActor in
+            var replaceErrorMessages = false
+            do {
+                let values = try validatedValues(for: currentState.parameters)
+                replaceErrorMessages = true
+                let request = PONativeAlternativePaymentMethodRequest(
+                    invoiceId: configuration.invoiceId,
+                    gatewayConfigurationId: configuration.gatewayConfigurationId,
+                    parameters: values
+                )
+                let response = try await invoicesService.initiatePayment(request: request)
+                switch response.nativeApm.state {
+                case .pendingCapture:
+                    send(event: .didSubmitParameters(additionalParametersExpected: false))
+                    await setAwaitingCaptureState(
+                        with: response.nativeApm.parameterValues,
+                        gateway: currentState.transactionDetails.gateway
+                    )
+                case .captured:
+                    send(event: .didSubmitParameters(additionalParametersExpected: false))
+                    let paymentProvider = await paymentProvider(
+                        with: response.nativeApm.parameterValues,
+                        gateway: currentState.transactionDetails.gateway
+                    )
+                    await setCapturedState(paymentProvider: paymentProvider)
+                case .customerInput:
+                    await restoreStartedStateAfterSubmission(nativeApm: response.nativeApm)
+                case .failed:
+                    fallthrough // swiftlint:disable:this fallthrough
+                @unknown default:
+                    throw POFailure(code: .generic(.mobile))
+                }
+            } catch {
+                attemptRecoverSubmissionError(error, replaceErrorMessages: replaceErrorMessages)
+            }
+        }
+        state = .submitting(.init(snapshot: currentState, task: task))
     }
 
     func confirmCapture() {
@@ -91,20 +152,17 @@ final class NativeAlternativePaymentDefaultInteractor:
     }
 
     override func cancel() {
-        // todo(andrii-vysotskyi): allow cancellation in all states except sink
-        logger.debug("Will attempt to cancel payment.")
         switch state {
-        case .started(let state) where state.isCancellable:
-            setFailureStateUnchecked(error: POFailure(code: .cancelled))
-        case .awaitingCapture(let state) where state.isCancellable:
-            if let cancellable = state.cancellable {
-                cancellable.cancel()
-            } else {
-                setFailureStateUnchecked(error: POFailure(code: .cancelled))
-            }
+        case .starting(let currentState):
+            currentState.task.cancel()
+        case .submitting(let currentState):
+            currentState.task.cancel()
+        case .awaitingCapture(let currentState):
+            currentState.task?.cancel()
         default:
-            logger.debug("Ignored cancellation attempt from unsupported state: \(state)")
+            break
         }
+        setFailureState(error: POFailure(code: .cancelled))
     }
 
     func didRequestCancelConfirmation() {
@@ -129,275 +187,25 @@ final class NativeAlternativePaymentDefaultInteractor:
     // MARK: - Starting State
 
     @MainActor
-    private func continueStartUnchecked() async {
-        let details: PONativeAlternativePaymentMethodTransactionDetails
-        do {
-            let request = PONativeAlternativePaymentMethodTransactionDetailsRequest(
-                invoiceId: configuration.invoiceId, gatewayConfigurationId: configuration.gatewayConfigurationId
-            )
-            details = try await invoicesService.nativeAlternativePaymentMethodTransactionDetails(request: request)
-        } catch {
-            setFailureStateUnchecked(error: error)
+    private func setStartedState(transactionDetails: PONativeAlternativePaymentMethodTransactionDetails) async {
+        let parameters = await createParameters(specifications: transactionDetails.parameters)
+        guard case .starting = state else {
+            logger.debug("Ignoring attempt to set started state in unsupported state: \(state).")
             return
         }
-        switch details.state {
-        case .customerInput, nil:
-            if details.parameters.isEmpty {
-                logger.debug("Will set started state with empty inputs, this may be unexpected")
-            }
-            let startedState = State.Started(
-                gateway: details.gateway,
-                invoice: details.invoice,
-                parameters: await createParameters(specifications: details.parameters),
-                isCancellable: disableDuration(of: configuration.secondaryAction).isZero
-            )
-            setStateUnchecked(.started(startedState))
-            send(event: .didStart)
-            logger.info("Did start payment, waiting for parameters")
-            enableCancellationAfterDelay()
-        case .pendingCapture:
-            logger.debug("No more parameters to submit, waiting for capture")
-            await setAwaitingCaptureStateUnchecked(gateway: details.gateway, parameterValues: details.parameterValues)
-        case .captured:
-            await setCapturedStateUnchecked(gateway: details.gateway, parameterValues: details.parameterValues)
-        case .failed:
-            fallthrough // swiftlint:disable:this fallthrough
-        @unknown default:
-            let failure = POFailure(code: .generic(.mobile))
-            setFailureStateUnchecked(error: failure)
+        if transactionDetails.parameters.isEmpty {
+            logger.debug("Will set started state with empty inputs, this may be unexpected.")
         }
-    }
-
-    // MARK: - Submission State
-
-    @MainActor
-    private func continueSubmissionUnchecked(
-        startedState: NativeAlternativePaymentInteractorState.Started, values: [String: String]
-    ) async {
-        let request = PONativeAlternativePaymentMethodRequest(
-            invoiceId: configuration.invoiceId,
-            gatewayConfigurationId: configuration.gatewayConfigurationId,
-            parameters: values
+        let startedState = State.Started(
+            transactionDetails: transactionDetails,
+            parameters: parameters,
+            isCancellable: disableDuration(of: configuration.secondaryAction).isZero
         )
-        let response: PONativeAlternativePaymentMethodResponse
-        do {
-            response = try await invoicesService.initiatePayment(request: request)
-        } catch {
-            restoreStartedStateAfterSubmissionFailureIfPossible(error, replaceErrorMessages: true)
-            return
-        }
-        switch response.nativeApm.state {
-        case .pendingCapture:
-            send(event: .didSubmitParameters(additionalParametersExpected: false))
-            await setAwaitingCaptureStateUnchecked(
-                gateway: startedState.gateway, parameterValues: response.nativeApm.parameterValues
-            )
-        case .captured:
-            send(event: .didSubmitParameters(additionalParametersExpected: false))
-            await setCapturedStateUnchecked(
-                gateway: startedState.gateway, parameterValues: response.nativeApm.parameterValues
-            )
-        case .customerInput:
-            await restoreStartedStateAfterSubmission(nativeApm: response.nativeApm)
-        case .failed:
-            fallthrough // swiftlint:disable:this fallthrough
-        @unknown default:
-            let failure = POFailure(code: .generic(.mobile))
-            setFailureStateUnchecked(error: failure)
-        }
+        state = .started(startedState)
+        send(event: .didStart)
+        logger.info("Did start payment, waiting for parameters.")
+        enableCancellationAfterDelay()
     }
-
-    // MARK: - Awaiting Capture State
-
-    @MainActor
-    private func setAwaitingCaptureStateUnchecked(
-        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway,
-        parameterValues: PONativeAlternativePaymentMethodParameterValues?
-    ) async {
-        guard configuration.paymentConfirmation.waitsConfirmation else {
-            logger.info("Won't await payment capture because waitsPaymentConfirmation is set to false")
-            setSubmittedUnchecked()
-            return
-        }
-        let customerActionMessage = parameterValues?.customerActionMessage ?? gateway.customerActionMessage
-        let additionalActionExpected = customerActionMessage != nil
-        send(event: .willWaitForCaptureConfirmation(additionalActionExpected: additionalActionExpected))
-        let (logoImage, actionImage) = await imagesRepository.images(
-            at: logoUrl(gateway: gateway, parameterValues: parameterValues), gateway.customerActionImageUrl
-        )
-        let shouldConfirmCapture = additionalActionExpected && configuration.paymentConfirmation.confirmButton != nil
-        let awaitingCaptureState = State.AwaitingCapture(
-            paymentProvider: .init(name: parameterValues?.providerName, image: logoImage),
-            customerAction: customerActionMessage.map { message in
-                .init(message: message, image: actionImage)
-            },
-            isCancellable: disableDuration(of: configuration.paymentConfirmation.secondaryAction).isZero,
-            isDelayed: false,
-            shouldConfirmCapture: shouldConfirmCapture
-        )
-        setStateUnchecked(.awaitingCapture(awaitingCaptureState))
-        if !shouldConfirmCapture {
-            confirmCapture(force: true)
-        }
-        enableCaptureCancellationAfterDelay()
-    }
-
-    private func confirmCapture(force: Bool) {
-        guard case .awaitingCapture(var currentState) = state else {
-            logger.debug("Ignoring attempt to confirm capture from unsupported state: \(state).")
-            return
-        }
-        guard (currentState.shouldConfirmCapture || force) && currentState.cancellable == nil else {
-            logger.debug("Payment is already being captured, ignored.")
-            return
-        }
-        if !force {
-            delegate?.nativeAlternativePaymentMethodDidEmitEvent(.didConfirmPayment)
-        }
-        let request = PONativeAlternativePaymentCaptureRequest(
-            invoiceId: configuration.invoiceId,
-            gatewayConfigurationId: configuration.gatewayConfigurationId,
-            timeout: configuration.paymentConfirmation.timeout
-        )
-        let task = Task { @MainActor in
-            do {
-                try await invoicesService.captureNativeAlternativePayment(request: request)
-                await setCapturedStateUnchecked(paymentProvider: currentState.paymentProvider)
-            } catch {
-                setFailureStateUnchecked(error: error)
-            }
-        }
-        currentState.cancellable = AnyCancellable(task.cancel)
-        currentState.shouldConfirmCapture = false
-        self.state = .awaitingCapture(currentState)
-        logger.info("Waiting for invoice capture confirmation")
-        schedulePaymentConfirmationDelay()
-    }
-
-    private func schedulePaymentConfirmationDelay() {
-        guard let timeInterval = configuration.paymentConfirmation.showProgressIndicatorAfter else {
-            return
-        }
-        Timer.scheduledTimer(withTimeInterval: timeInterval, repeats: false) { [weak self] _ in
-            guard let self, case .awaitingCapture(var awaitingCaptureState) = self.state else {
-                return
-            }
-            awaitingCaptureState.isDelayed = true
-            setStateUnchecked(.awaitingCapture(awaitingCaptureState))
-        }
-    }
-
-    // MARK: - Captured State
-
-    @MainActor
-    private func setCapturedStateUnchecked(
-        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway,
-        parameterValues: PONativeAlternativePaymentMethodParameterValues?
-    ) async {
-        let logoImage = await imagesRepository.image(
-            at: logoUrl(gateway: gateway, parameterValues: parameterValues)
-        )
-        let paymentProvider = State.PaymentProvider(name: parameterValues?.providerName, image: logoImage)
-        await setCapturedStateUnchecked(paymentProvider: paymentProvider)
-    }
-
-    @MainActor
-    private func setCapturedStateUnchecked(
-        paymentProvider: NativeAlternativePaymentInteractorState.PaymentProvider
-    ) async {
-        logger.info("Did receive invoice capture confirmation")
-        guard configuration.paymentConfirmation.waitsConfirmation else {
-            logger.info("Should't wait for confirmation, so setting submitted state instead of captured.")
-            setSubmittedUnchecked()
-            return
-        }
-        let capturedState = State.Captured(paymentProvider: paymentProvider)
-        setStateUnchecked(.captured(capturedState))
-        send(event: .didCompletePayment)
-        if !configuration.skipSuccessScreen {
-            try? await Task.sleep(seconds: Constants.captureCompletionDelay)
-        }
-        completion(.success(()))
-    }
-
-    // MARK: - Started State Restoration
-
-    private func restoreStartedStateAfterSubmissionFailureIfPossible(_ error: Error, replaceErrorMessages: Bool) {
-        logger.info("Did fail to submit parameters: \(error)")
-        guard let failure = error as? POFailure else {
-            setFailureStateUnchecked(error: error)
-            return
-        }
-        var startedState: State.Started
-        switch state {
-        case let .submitting(state), let .started(state):
-            startedState = state
-        default:
-            return
-        }
-        let invalidFields = failure.invalidFields.map { invalidFields in
-            Dictionary(grouping: invalidFields, by: \.name).compactMapValues(\.first)
-        }
-        guard let invalidFields = invalidFields, !invalidFields.isEmpty else {
-            logger.debug("Submission error is not recoverable, aborting")
-            setFailureStateUnchecked(error: failure)
-            return
-        }
-        for (offset, parameter) in startedState.parameters.enumerated() {
-            let errorMessage: String?
-            if !replaceErrorMessages {
-                errorMessage = invalidFields[parameter.specification.key]?.message
-            } else if invalidFields[parameter.specification.key] != nil {
-                errorMessage = self.errorMessage(parameterType: parameter.specification.type)
-            } else {
-                errorMessage = nil
-            }
-            startedState.parameters[offset].recentErrorMessage = errorMessage
-        }
-        setStateUnchecked(.started(startedState))
-        send(event: .didFailToSubmitParameters(failure: failure))
-        logger.debug("One or more parameters are not valid: \(invalidFields), waiting for parameters to update")
-    }
-
-    @MainActor
-    private func restoreStartedStateAfterSubmission(
-        nativeApm: PONativeAlternativePaymentMethodResponse.NativeApm
-    ) async {
-        guard case var .submitting(startedState) = state else {
-            return
-        }
-        startedState.parameters = await createParameters(
-            specifications: nativeApm.parameterDefinitions ?? []
-        )
-        setStateUnchecked(.started(startedState))
-        send(event: .didSubmitParameters(additionalParametersExpected: true))
-        logger.debug("More parameters are expected, waiting for parameters to update")
-    }
-
-    // MARK: - Submitted State
-
-    private func setSubmittedUnchecked() {
-        setStateUnchecked(.submitted)
-        completion(.success(()))
-    }
-
-    // MARK: - Failure State
-
-    private func setFailureStateUnchecked(error: Error) {
-        logger.warn("Did fail to process native payment: \(error)")
-        let failure: POFailure
-        if let error = error as? POFailure {
-            failure = error
-        } else {
-            logger.debug("Unexpected error type: \(error)")
-            failure = POFailure(code: .generic(.mobile), underlyingError: error)
-        }
-        setStateUnchecked(.failure(failure))
-        send(event: .didFail(failure: failure))
-        completion(.failure(failure))
-    }
-
-    // MARK: - Cancellation Availability
 
     private func enableCancellationAfterDelay() {
         let disabledFor = disableDuration(of: configuration.secondaryAction)
@@ -408,17 +216,214 @@ final class NativeAlternativePaymentDefaultInteractor:
         Task { @MainActor in
             try? await Task.sleep(seconds: disabledFor)
             switch state {
-            case .started(var state):
-                state.isCancellable = true
-                setStateUnchecked(.started(state))
-            case .submitting(var state):
-                state.isCancellable = true
-                setStateUnchecked(.submitting(snapshot: state))
+            case .started(var currentState):
+                currentState.isCancellable = true
+                state = .started(currentState)
+            case .submitting(let currentState):
+                var updatedSnapshot = currentState.snapshot
+                updatedSnapshot.isCancellable = true
+                state = .submitting(.init(snapshot: updatedSnapshot, task: currentState.task))
             default:
                 break
             }
         }
     }
+
+    // MARK: - Awaiting Capture State
+
+    @MainActor
+    private func setAwaitingCaptureState(
+        with parameterValues: PONativeAlternativePaymentMethodParameterValues?,
+        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway
+    ) async {
+        let paymentProvider = await paymentProvider(with: parameterValues, gateway: gateway)
+        if configuration.paymentConfirmation.waitsConfirmation {
+            let customerAction = await customerAction(with: parameterValues, gateway: gateway)
+            switch state {
+            case .starting, .submitting:
+                break
+            default:
+                logger.debug("Ignoring attempt to wait for capture from unsupported state.")
+                return
+            }
+            send(event: .willWaitForCaptureConfirmation(additionalActionExpected: customerAction != nil))
+            let shouldConfirmCapture = customerAction != nil && configuration.paymentConfirmation.confirmButton != nil
+            let awaitingCaptureState = State.AwaitingCapture(
+                paymentProvider: paymentProvider,
+                customerAction: customerAction,
+                isCancellable: disableDuration(of: configuration.paymentConfirmation.secondaryAction).isZero,
+                isDelayed: false,
+                shouldConfirmCapture: shouldConfirmCapture
+            )
+            state = .awaitingCapture(awaitingCaptureState)
+            if !shouldConfirmCapture {
+                confirmCapture(force: true)
+            }
+            enableCaptureCancellationAfterDelay()
+        } else {
+            logger.info("Payment capture wasn't requested, will attempt to set captured state directly.")
+            await setCapturedState(paymentProvider: paymentProvider)
+        }
+    }
+
+    private func confirmCapture(force: Bool) {
+        guard case .awaitingCapture(let currentState) = state else {
+            logger.debug("Ignoring attempt to confirm capture from unsupported state: \(state).")
+            return
+        }
+        guard currentState.shouldConfirmCapture || force else {
+            logger.debug("Payment is already being captured, ignored.")
+            return
+        }
+        if currentState.shouldConfirmCapture {
+            delegate?.nativeAlternativePaymentMethodDidEmitEvent(.didConfirmPayment)
+        }
+        let request = PONativeAlternativePaymentCaptureRequest(
+            invoiceId: configuration.invoiceId,
+            gatewayConfigurationId: configuration.gatewayConfigurationId,
+            timeout: configuration.paymentConfirmation.timeout
+        )
+        var newState = currentState
+        newState.task = Task { @MainActor in
+            do {
+                try await invoicesService.captureNativeAlternativePayment(request: request)
+                await setCapturedState(paymentProvider: currentState.paymentProvider)
+            } catch {
+                setFailureState(error: error)
+            }
+        }
+        newState.shouldConfirmCapture = false
+        state = .awaitingCapture(newState)
+        logger.info("Waiting for invoice capture confirmation.")
+        schedulePaymentConfirmationDelay()
+    }
+
+    private func schedulePaymentConfirmationDelay() {
+        guard let timeInterval = configuration.paymentConfirmation.showProgressIndicatorAfter else {
+            return
+        }
+        Task { @MainActor in
+            try? await Task.sleep(seconds: timeInterval)
+            guard case .awaitingCapture(var newState) = state else {
+                return
+            }
+            newState.isDelayed = true
+            state = .awaitingCapture(newState)
+        }
+    }
+
+    private func customerAction(
+        with parameterValues: PONativeAlternativePaymentMethodParameterValues?,
+        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway
+    ) async -> NativeAlternativePaymentInteractorState.CaptureCustomerAction? {
+        let message = parameterValues?.customerActionMessage ?? gateway.customerActionMessage
+        guard let message else {
+            return nil
+        }
+        let image = await imagesRepository.image(at: gateway.customerActionImageUrl)
+        return .init(message: message, image: image)
+    }
+
+    // MARK: - Captured State
+
+    @MainActor
+    private func setCapturedState(paymentProvider: NativeAlternativePaymentInteractorState.PaymentProvider) async {
+        guard !state.isSink else {
+            logger.debug("Already in a sink state, ignoring attempt to set captured state.")
+            return
+        }
+        if configuration.paymentConfirmation.waitsConfirmation {
+            state = .captured(.init(paymentProvider: paymentProvider))
+            send(event: .didCompletePayment)
+            if !configuration.skipSuccessScreen {
+                try? await Task.sleep(seconds: Constants.captureCompletionDelay)
+            }
+        } else {
+            logger.info("Shouldn't wait for confirmation, setting submitted state instead.")
+            state = .submitted
+        }
+        completion(.success(()))
+    }
+
+    // MARK: - Submission Recovery
+
+    private func attemptRecoverSubmissionError(_ error: Error, replaceErrorMessages: Bool) {
+        logger.info("Did fail to submit parameters: \(error)")
+        guard let failure = error as? POFailure else {
+            setFailureState(error: error)
+            return
+        }
+        var newState: State.Started
+        switch state {
+        case let .started(state):
+            newState = state
+        case let .submitting(state):
+            newState = state.snapshot
+        default:
+            logger.debug("Ignoring attempt to recover submission error from unsupported state: \(state).")
+            return
+        }
+        let invalidFields = failure.invalidFields.map { invalidFields in
+            Dictionary(grouping: invalidFields, by: \.name).compactMapValues(\.first)
+        }
+        guard let invalidFields = invalidFields, !invalidFields.isEmpty else {
+            logger.debug("Submission error is not recoverable, aborting.")
+            setFailureState(error: failure)
+            return
+        }
+        for (offset, parameter) in newState.parameters.enumerated() {
+            let errorMessage: String?
+            if !replaceErrorMessages {
+                errorMessage = invalidFields[parameter.specification.key]?.message
+            } else if invalidFields[parameter.specification.key] != nil {
+                errorMessage = self.errorMessage(parameterType: parameter.specification.type)
+            } else {
+                errorMessage = nil
+            }
+            newState.parameters[offset].recentErrorMessage = errorMessage
+        }
+        state = .started(newState)
+        send(event: .didFailToSubmitParameters(failure: failure))
+        logger.debug("One or more parameters are not valid: \(invalidFields), waiting for parameters to update.")
+    }
+
+    // MARK: - Submission Completion
+
+    @MainActor
+    private func restoreStartedStateAfterSubmission(
+        nativeApm: PONativeAlternativePaymentMethodResponse.NativeApm
+    ) async {
+        guard case let .submitting(currentState) = state else {
+            return
+        }
+        var newState = currentState.snapshot
+        newState.parameters = await createParameters(specifications: nativeApm.parameterDefinitions ?? [])
+        state = .started(newState)
+        send(event: .didSubmitParameters(additionalParametersExpected: true))
+        logger.debug("More parameters are expected, waiting for parameters to update.")
+    }
+
+    // MARK: - Failure State
+
+    private func setFailureState(error: Error) {
+        guard !state.isSink else {
+            logger.debug("Already in a sink state, ignoring attempt to set failure state.")
+            return
+        }
+        logger.warn("Did fail to process native payment: \(error)")
+        let failure: POFailure
+        if let error = error as? POFailure {
+            failure = error
+        } else {
+            logger.debug("Unexpected error type: \(error)")
+            failure = POFailure(code: .generic(.mobile), underlyingError: error)
+        }
+        state = .failure(failure)
+        send(event: .didFail(failure: failure))
+        completion(.failure(failure))
+    }
+
+    // MARK: - Cancellation Availability
 
     private func enableCaptureCancellationAfterDelay() {
         let disabledFor = disableDuration(of: configuration.paymentConfirmation.secondaryAction)
@@ -428,11 +433,11 @@ final class NativeAlternativePaymentDefaultInteractor:
         }
         Task { @MainActor in
             try? await Task.sleep(seconds: disabledFor)
-            guard case .awaitingCapture(var awaitingState) = state else {
+            guard case .awaitingCapture(var newState) = state else {
                 return
             }
-            awaitingState.isCancellable = true
-            setStateUnchecked(.awaitingCapture(awaitingState))
+            newState.isCancellable = true
+            state = .awaitingCapture(newState)
         }
     }
 
@@ -445,7 +450,7 @@ final class NativeAlternativePaymentDefaultInteractor:
     }
 
     private func didUpdate(parameter: NativeAlternativePaymentInteractorState.Parameter, to value: String) {
-        logger.debug("Did update parameter value '\(value)' for '\(parameter.specification.key)' key")
+        logger.debug("Did update parameter value '\(value)' for '\(parameter.specification.key)' key.")
         let parametersChangedEvent = PONativeAlternativePaymentEvent.ParametersChanged(
             parameter: parameter.specification, value: value
         )
@@ -463,10 +468,6 @@ final class NativeAlternativePaymentDefaultInteractor:
     }
 
     // MARK: - Utils
-
-    private func setStateUnchecked(_ state: NativeAlternativePaymentInteractorState) {
-        self.state = state
-    }
 
     @MainActor
     private func createParameters(
@@ -504,17 +505,23 @@ final class NativeAlternativePaymentDefaultInteractor:
         return String(resource: resource)
     }
 
-    private func logoUrl(
-        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway,
-        parameterValues: PONativeAlternativePaymentMethodParameterValues?
-    ) -> URL? {
-        if parameterValues?.providerName != nil {
-            return parameterValues?.providerLogoUrl
+    private func paymentProvider(
+        with parameterValues: PONativeAlternativePaymentMethodParameterValues?,
+        gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway
+    ) async -> NativeAlternativePaymentInteractorState.PaymentProvider {
+        if let parameterValues {
+            if let url = parameterValues.providerLogoUrl, let image = await imagesRepository.image(at: url) {
+                return .init(name: nil, image: image)
+            }
+            if let name = parameterValues.providerName {
+                return .init(name: name, image: nil)
+            }
         }
         guard !configuration.paymentConfirmation.hideGatewayDetails else {
-            return nil
+            return .init(name: nil, image: nil)
         }
-        return gateway.logoUrl
+        let gatewayLogoImage = await imagesRepository.image(at: gateway.logoUrl)
+        return .init(name: nil, image: gatewayLogoImage)
     }
 
     private func disableDuration(of action: PONativeAlternativePaymentConfiguration.SecondaryAction?) -> TimeInterval {
@@ -534,15 +541,9 @@ final class NativeAlternativePaymentDefaultInteractor:
         guard !parameters.isEmpty else {
             return
         }
-        let defaultValues = await withCheckedContinuation { continuation in
-            if let delegate {
-                delegate.nativeAlternativePaymentMethodDefaultValues(
-                    for: parameters.map(\.specification), completion: { continuation.resume(returning: $0) }
-                )
-            } else {
-                continuation.resume(returning: [:])
-            }
-        }
+        let defaultValues = await delegate?.nativeAlternativePayment(
+            defaultValuesFor: parameters.map(\.specification)
+        ) ?? [:]
         for (offset, parameter) in parameters.enumerated() {
             let defaultValue: String?
             if let value = defaultValues[parameter.specification.key] {
@@ -584,7 +585,7 @@ final class NativeAlternativePaymentDefaultInteractor:
                 normalizedValue = POPhoneNumberFormatter().normalized(number: value)
             }
             if let normalizedValue, normalizedValue != parameter.value {
-                logger.debug("Will use updated value '\(normalizedValue)' for key '\(parameter.specification.key)'")
+                logger.debug("Will use updated value '\(normalizedValue)' for key '\(parameter.specification.key)'.")
             }
             if let invalidField = validate(value: normalizedValue ?? "", specification: parameter.specification) {
                 invalidFields.append(invalidField)

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
@@ -186,7 +186,6 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     // MARK: - Starting State
 
-    @MainActor
     private func setStartedState(transactionDetails: PONativeAlternativePaymentMethodTransactionDetails) async {
         let parameters = await createParameters(specifications: transactionDetails.parameters)
         guard case .starting = state else {
@@ -231,7 +230,6 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     // MARK: - Awaiting Capture State
 
-    @MainActor
     private func setAwaitingCaptureState(
         with parameterValues: PONativeAlternativePaymentMethodParameterValues?,
         gateway: PONativeAlternativePaymentMethodTransactionDetails.Gateway
@@ -326,7 +324,6 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     // MARK: - Captured State
 
-    @MainActor
     private func setCapturedState(paymentProvider: NativeAlternativePaymentInteractorState.PaymentProvider) async {
         guard !state.isSink else {
             logger.debug("Already in a sink state, ignoring attempt to set captured state.")
@@ -389,7 +386,6 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     // MARK: - Submission Completion
 
-    @MainActor
     private func restoreStartedStateAfterSubmission(
         nativeApm: PONativeAlternativePaymentMethodResponse.NativeApm
     ) async {
@@ -469,7 +465,6 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     // MARK: - Utils
 
-    @MainActor
     private func createParameters(
         specifications: [PONativeAlternativePaymentMethodParameter]
     ) async -> [NativeAlternativePaymentInteractorState.Parameter] {
@@ -534,7 +529,6 @@ final class NativeAlternativePaymentDefaultInteractor:
     // MARK: - Default Values
 
     /// Updates parameters with default values.
-    @MainActor
     private func setDefaultValues(
         parameters: inout [NativeAlternativePaymentInteractorState.Parameter]
     ) async {

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
@@ -407,7 +407,7 @@ final class NativeAlternativePaymentDefaultInteractor:
 
     private func setFailureState(error: Error) {
         guard !state.isSink else {
-            logger.debug("Already in a sink state, ignoring attempt to set failure state.")
+            logger.debug("Already in a sink state, ignoring attempt to set failure state with: \(error).")
             return
         }
         logger.warn("Did fail to process native payment: \(error)")

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentDefaultInteractor.swift
@@ -263,7 +263,7 @@ final class NativeAlternativePaymentDefaultInteractor:
             }
             enableCaptureCancellationAfterDelay()
         } else {
-            logger.info("Payment capture wasn't requested, will attempt to set captured state directly.")
+            logger.info("Payment capture wasn't requested, will attempt to set submitted state directly.")
             setSubmittedState()
         }
     }

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentInteractor.swift
@@ -5,6 +5,7 @@
 //  Created by Andrii Vysotskyi on 29.02.2024.
 //
 
+@MainActor
 protocol NativeAlternativePaymentInteractor: Interactor<NativeAlternativePaymentInteractorState> {
 
     /// Configuration.

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/Interactor/NativeAlternativePaymentInteractorState.swift
@@ -65,6 +65,9 @@ enum NativeAlternativePaymentInteractorState {
 
         /// Payment provider details.
         let paymentProvider: PaymentProvider
+
+        /// Task that handles completion invocation.
+        let completionTask: Task<Void, Never>
     }
 
     struct Parameter {

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/View/PONativeAlternativePaymentView.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/View/PONativeAlternativePaymentView.swift
@@ -37,6 +37,7 @@ public struct PONativeAlternativePaymentView: View {
                 .animation(.default, value: viewModel.state.isCaptured)
         }
         .onAppear(perform: viewModel.start)
+        .onDisappear(perform: viewModel.stop)
         .poConfirmationDialog(item: $viewModel.state.confirmationDialog)
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/ViewModel/DefaultNativeAlternativePaymentViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/ViewModel/DefaultNativeAlternativePaymentViewModel.swift
@@ -18,10 +18,6 @@ final class DefaultNativeAlternativePaymentViewModel: ViewModel {
         observeChanges(interactor: interactor)
     }
 
-    deinit {
-        interactor.cancel()
-    }
-
     // MARK: - NativeAlternativePaymentViewModel
 
     @AnimatablePublished
@@ -29,6 +25,10 @@ final class DefaultNativeAlternativePaymentViewModel: ViewModel {
 
     func start() {
         $state.performWithoutAnimation(interactor.start)
+    }
+
+    func stop() {
+        interactor.cancel()
     }
 
     // MARK: - Private Nested Types

--- a/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/ViewModel/DefaultNativeAlternativePaymentViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/NativeAlternativePayment/ViewModel/DefaultNativeAlternativePaymentViewModel.swift
@@ -72,7 +72,7 @@ final class DefaultNativeAlternativePaymentViewModel: ViewModel {
         case .started(let state):
             update(with: state)
         case .submitting(let state):
-            update(withSubmittingState: state)
+            update(withSubmittingState: state.snapshot)
         case .awaitingCapture(let state):
             update(with: state)
         case .captured(let state) where !configuration.skipSuccessScreen:
@@ -141,8 +141,9 @@ final class DefaultNativeAlternativePaymentViewModel: ViewModel {
     }
 
     private func createTitleSection(state: InteractorState.Started) -> NativeAlternativePaymentViewModelSection? {
-        let title = configuration.title
-        ?? String(resource: .NativeAlternativePayment.title, replacements: state.gateway.displayName)
+        let gatewayDisplayName = state.transactionDetails.gateway.displayName
+        // swiftlint:disable:next line_length
+        let title = configuration.title ?? String(resource: .NativeAlternativePayment.title, replacements: gatewayDisplayName)
         guard !title.isEmpty else {
             return nil
         }
@@ -392,9 +393,9 @@ final class DefaultNativeAlternativePaymentViewModel: ViewModel {
         if let customTitle = configuration.primaryActionTitle {
             title = customTitle
         } else {
-            priceFormatter.currencyCode = state.invoice.currencyCode
-            // swiftlint:disable:next legacy_objc_type
-            if let formattedAmount = priceFormatter.string(from: state.invoice.amount as NSDecimalNumber) {
+            priceFormatter.currencyCode = state.transactionDetails.invoice.currencyCode
+            // swiftlint:disable:next legacy_objc_type line_length
+            if let formattedAmount = priceFormatter.string(from: state.transactionDetails.invoice.amount as NSDecimalNumber) {
                 title = String(resource: .NativeAlternativePayment.Button.submitAmount, replacements: formattedAmount)
             } else {
                 title = String(resource: .NativeAlternativePayment.Button.submit)

--- a/Tests/ProcessOutUITests/Sources/Integration/CardUpdate/DefaultCardUpdateInteractorTests.swift
+++ b/Tests/ProcessOutUITests/Sources/Integration/CardUpdate/DefaultCardUpdateInteractorTests.swift
@@ -29,7 +29,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
         // When
         let expectation = XCTestExpectation()
         delegate.cardInformationFromClosure = { [unowned sut] _ in
-            if sut.state == .starting {
+            if case .starting = sut.state {
                 expectation.fulfill()
             }
             return nil
@@ -132,7 +132,9 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
         sut.cancel()
 
         // Then
-        XCTAssertEqual(sut.state, .completed)
+        if case .completed = sut.state { } else {
+            XCTFail("Expected completed state.")
+        }
     }
 
     // MARK: - Update CVC
@@ -143,13 +145,14 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
         let configuration = POCardUpdateConfiguration(cardId: "")
         let sut = createSut(configuration: configuration)
         sut.start()
-        let oldState = sut.state
 
         // When
         sut.update(cvc: "123")
 
         // Then
-        XCTAssertEqual(sut.state, oldState)
+        if case .starting = sut.state { } else {
+            XCTFail("Expected starting state.")
+        }
     }
 
     @MainActor

--- a/Tests/ProcessOutUITests/Sources/Integration/CardUpdate/DefaultCardUpdateInteractorTests.swift
+++ b/Tests/ProcessOutUITests/Sources/Integration/CardUpdate/DefaultCardUpdateInteractorTests.swift
@@ -20,7 +20,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
     // MARK: - Start
 
     @MainActor
-    func test_start_whenCardInfoIsNotSet_setsStartingState() {
+    func test_start_whenCardInfoIsNotSet_setsStartingState() async {
         // Given
         let delegate = CardUpdateDelegateMock()
         let configuration = POCardUpdateConfiguration(cardId: "")
@@ -35,21 +35,23 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
             return nil
         }
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // Then
-        wait(for: [expectation])
+        await fulfillment(of: [expectation])
     }
 
     // MARK: - Scheme Resolve
 
     @MainActor
-    func test_start_whenCardSchemeIsSetInConfiguration_setsStartedStateWithIt() {
+    func test_start_whenCardSchemeIsSetInConfiguration_setsStartedStateWithIt() async {
         // Given
         let configuration = POCardUpdateConfiguration(cardId: "", cardInformation: .init(scheme: "visa"))
         let sut = createSut(configuration: configuration)
 
         // When
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // Then
         guard case .started(let startedState) = sut.state else {
@@ -60,7 +62,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
     }
 
     @MainActor
-    func test_start_whenPreferredCardSchemeIsAvailable_setsStartedStateWithIt() {
+    func test_start_whenPreferredCardSchemeIsAvailable_setsStartedStateWithIt() async {
         // Given
         let configuration = POCardUpdateConfiguration(
             cardId: "", cardInformation: .init(scheme: "visa", preferredScheme: "carte bancaire")
@@ -69,6 +71,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
 
         // When
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // Then
         guard case .started(let startedState) = sut.state else {
@@ -80,7 +83,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
     }
 
     @MainActor
-    func test_start_whenCardSchemeIsNotSetAndIinIsSet_attemptsToResolve() {
+    func test_start_whenCardSchemeIsNotSetAndIinIsSet_attemptsToResolve() async {
         // Given
         let configuration = POCardUpdateConfiguration(cardId: "", cardInformation: .init(iin: "424242"))
         let sut = createSut(configuration: configuration)
@@ -95,11 +98,11 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        await fulfillment(of: [expectation])
     }
 
     @MainActor
-    func test_start_whenCardSchemeIsNotSetAndMaskedNumberIsSet_attemptsToResolve() {
+    func test_start_whenCardSchemeIsNotSetAndMaskedNumberIsSet_attemptsToResolve() async {
         // Given
         let configuration = POCardUpdateConfiguration(
             cardId: "", cardInformation: .init(maskedNumber: "4242 42** **42")
@@ -116,17 +119,18 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        await fulfillment(of: [expectation])
     }
 
     // MARK: - Cancel
 
     @MainActor
-    func test_cancel_whenStarted() {
+    func test_cancel_whenStarted() async {
         // Given
         let configuration = POCardUpdateConfiguration(cardId: "", cardInformation: .init(scheme: "visa"))
         let sut = createSut(configuration: configuration)
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // When
         sut.cancel()
@@ -156,11 +160,12 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
     }
 
     @MainActor
-    func test_updateCvc_whenStarted_updatesState() {
+    func test_updateCvc_whenStarted_updatesState() async {
         // Given
         let configuration = POCardUpdateConfiguration(cardId: "", cardInformation: .init(scheme: "visa"))
         let sut = createSut(configuration: configuration)
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // When
         sut.update(cvc: "1 23 45")
@@ -175,11 +180,12 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
     // MARK: - Submit
 
     @MainActor
-    func test_submit_whenCvcIsNotSet_causesError() {
+    func test_submit_whenCvcIsNotSet_causesError() async {
         // Given
         let configuration = POCardUpdateConfiguration(cardId: "", cardInformation: .init(scheme: "visa"))
         let sut = createSut(configuration: configuration)
         sut.start()
+        try? await Task.sleep(for: .seconds(1))
 
         // When
         sut.submit()
@@ -191,20 +197,21 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        await fulfillment(of: [expectation])
     }
 
     @MainActor
-    func test_submit_whenValidCvcIsSet_completes() {
+    func test_submit_whenValidCvcIsSet_completes() async {
         // Given
         let configuration = POCardUpdateConfiguration(
             cardId: "card_ZbHkl2Uh3Udafx2cbb2uN4pP2evwHPyf", cardInformation: .init(scheme: "visa")
         )
         let sut = createSut(configuration: configuration)
         sut.start()
-        sut.update(cvc: "123")
+        try? await Task.sleep(for: .seconds(1))
 
         // When
+        sut.update(cvc: "123")
         sut.submit()
 
         // Then
@@ -214,7 +221,7 @@ final class DefaultCardUpdateInteractorTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: [expectation])
+        await fulfillment(of: [expectation])
     }
 
     // MARK: - Private Properties

--- a/project.yml
+++ b/project.yml
@@ -78,7 +78,7 @@ targets:
   ProcessOutUITests:
     type: bundle.unit-test
     platform: iOS
-    deploymentTarget: "14.0"
+    deploymentTarget: "16.0"
     settings:
       TARGET_ROOT: $(PROJECT_DIR)/Tests/ProcessOutUITests
     dependencies:


### PR DESCRIPTION
## Description
Ensure that UI module lifecycle is ended properly (meaning completion invocation and related events) when screen is dismissed "externally" (e.g. interactively by user or programatically). Fix affects following screens: card tokenization, card update and native alternative payment.

Note that dynamic checkout fix is not part of this PR and will be provided separately.

### Minor improvements:
- Accept full card number when resolving issuer information.
- Resolve actor related warnings in UI module
- Prevent errors from redundant fonts registration in generated code (legacy)

## Jira Issue
https://checkout.atlassian.net/browse/POM-423
