### PR TITLE
feat(ad-hoc): delay sequential web authentications

### DIFF
--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,4 @@
 {
-  "originHash" : "8f250d3cf19fc47446f324890a784ded5493b6143de5d0aef317488859119617",
   "pins" : [
     {
       "identity" : "checkout-3ds-sdk-ios",
@@ -24,10 +23,10 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-cmark",
       "state" : {
-        "branch" : "gfm",
-        "revision" : "fc07ab5da47975c5ef5f336acadfc02e8f706d30"
+        "revision" : "3ccff77b2dc5b96b77db3da0d68d28068593fa53",
+        "version" : "0.5.0"
       }
     }
   ],
-  "version" : 3
+  "version" : 2
 }

--- a/Sources/ProcessOut/Sources/Api/ProcessOut.swift
+++ b/Sources/ProcessOut/Sources/Api/ProcessOut.swift
@@ -154,7 +154,9 @@ public final class ProcessOut {
         return DefaultCustomerActionsService(decoder: decoder, encoder: encoder, webSession: webSession)
     }()
 
-    private let webSession = DefaultWebAuthenticationSession()
+    private let webSession = ThrottledWebAuthenticationSessionDecorator(
+        session: DefaultWebAuthenticationSession()
+    )
 
     // MARK: - Private Methods
 

--- a/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphore.swift
+++ b/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphore.swift
@@ -1,0 +1,115 @@
+//
+//  AsyncSemaphore.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 10.10.2024.
+//
+
+import Foundation
+
+actor AsyncSemaphore {
+
+    // MARK: - Creating a Semaphore
+
+    /// Creates a semaphore.
+    init(value: UInt) {
+        initialValue = Int(value)
+        self.value = Int(value)
+    }
+
+    deinit {
+        let suspensions = self.suspensions
+        precondition(
+            suspensions.isEmpty, "AsyncSemaphore is deallocated while some task(s) are suspended waiting for a signal."
+        )
+    }
+
+    // MARK: - Semaphore
+
+    /// Decrements the semaphore.
+    ///
+    /// If the count is negative, the current task is suspended without blocking
+    /// the thread. Otherwise, no suspension occurs.
+    func wait() async {
+        value -= 1
+        guard value < 0 else {
+            return
+        }
+        await withUnsafeContinuation { continuation in
+            let suspension = AsyncSemaphoreSuspension()
+            if suspension.setContinuation(continuation) {
+                suspensions.insert(suspension, at: 0)
+            }
+        }
+    }
+
+    /// Decrements a semaphore with cancellation support.
+    ///
+    /// If the count is negative, the current task is suspended without blocking
+    /// the thread. Otherwise, no suspension occurs.
+    ///
+    /// If canceled before signalling, this function throws `CancellationError`.
+    func waitUnlessCancelled() async throws {
+        try Task.checkCancellation()
+        value -= 1
+        guard value < 0 else {
+            return
+        }
+        let suspension = AsyncSemaphoreSuspension()
+        try await withTaskCancellationHandler {
+            try await withUnsafeThrowingContinuation { continuation in
+                if suspension.setContinuation(continuation) {
+                    suspensions.insert(suspension, at: 0)
+                }
+            }
+        } onCancel: {
+            Task {
+                await self.cancel(suspension: suspension)
+            }
+        }
+    }
+
+    /// Signals the semaphore, incrementing its count.
+    ///
+    /// Increases the semaphore's count, potentially unblocking a suspended task
+    /// if the count transitions from negative to non-negative.
+    nonisolated func signal() {
+        Task {
+            await signalSemaphore()
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private let initialValue: Int
+
+    /// The semaphore value.
+    private var value: Int
+
+    /// As many elements as there are suspended tasks waiting for a signal.
+    private var suspensions: [AsyncSemaphoreSuspension] = []
+
+    // MARK: - Private Methods
+
+    private func incrementValue() {
+        if value == initialValue {
+            assertionFailure("The semaphore value cannot exceed its initial value.")
+        }
+        value += 1
+    }
+
+    // MARK: - Private Methods
+
+    private func cancel(suspension: AsyncSemaphoreSuspension) {
+        incrementValue()
+        if let index = suspensions.firstIndex(where: { $0 === suspension }) {
+            suspensions.remove(at: index)
+        }
+        suspension.cancel()
+    }
+
+    private func signalSemaphore() {
+        incrementValue()
+        suspensions.popLast()?.resume()
+    }
+}

--- a/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspension.swift
+++ b/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspension.swift
@@ -10,10 +10,10 @@ final class AsyncSemaphoreSuspension {
     func resume() {
         switch state {
         case .suspendedUnlessCancelled(let unsafeContinuation):
-            state = nil
+            state = .resumed
             unsafeContinuation.resume()
         case .suspended(let unsafeContinuation):
-            state = nil
+            state = .resumed
             unsafeContinuation.resume()
         case .cancelled:
             assertionFailure("Cannot resume a canceled suspension.")

--- a/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspension.swift
+++ b/Sources/ProcessOut/Sources/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspension.swift
@@ -1,0 +1,95 @@
+//
+//  AsyncSemaphoreSuspension.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 10.10.2024.
+//
+
+final class AsyncSemaphoreSuspension {
+
+    func resume() {
+        switch state {
+        case .suspendedUnlessCancelled(let unsafeContinuation):
+            state = nil
+            unsafeContinuation.resume()
+        case .suspended(let unsafeContinuation):
+            state = nil
+            unsafeContinuation.resume()
+        case .cancelled:
+            assertionFailure("Cannot resume a canceled suspension.")
+        case .resumed:
+            break
+        case nil:
+            state = .resumed
+        }
+    }
+
+    func cancel() {
+        switch state {
+        case .suspendedUnlessCancelled(let unsafeContinuation):
+            state = .cancelled
+            unsafeContinuation.resume(throwing: CancellationError())
+        case .suspended:
+            assertionFailure("Cancellation attempted on a continuation that does not support it.")
+        case .cancelled:
+            break
+        case .resumed:
+            assertionFailure("Cannot cancel a suspension that has already been resumed.")
+        case nil:
+            state = .cancelled
+        }
+    }
+
+    @discardableResult
+    func setContinuation(_ unsafeContinuation: UnsafeContinuation<Void, Error>) -> Bool {
+        switch state {
+        case .suspendedUnlessCancelled, .suspended:
+            preconditionFailure("The continuation is already established.")
+        case .cancelled:
+            unsafeContinuation.resume(throwing: CancellationError())
+        case .resumed:
+            unsafeContinuation.resume()
+        case nil:
+            state = .suspendedUnlessCancelled(unsafeContinuation)
+            return true
+        }
+        return false
+    }
+
+    @discardableResult
+    func setContinuation(_ unsafeContinuation: UnsafeContinuation<Void, Never>) -> Bool {
+        switch state {
+        case .suspendedUnlessCancelled, .suspended:
+            preconditionFailure("The continuation is already established.")
+        case .cancelled:
+            preconditionFailure("The suspension was canceled, but provided continuation doesn't support cancellation.")
+        case .resumed:
+            unsafeContinuation.resume()
+        case nil:
+            state = .suspended(unsafeContinuation)
+            return true
+        }
+        return false
+    }
+
+    // MARK: - Private Nested Types
+
+    private enum State {
+
+        /// Waiting for a signal, with support for cancellation.
+        case suspendedUnlessCancelled(UnsafeContinuation<Void, Error>)
+
+        /// Waiting for a signal, with no support for cancellation.
+        case suspended(UnsafeContinuation<Void, Never>)
+
+        /// Cancelled before we have started waiting.
+        case cancelled
+
+        /// Suspension is already resumed.
+        case resumed
+    }
+
+    // MARK: - Private Properties
+
+    private var state: State?
+}

--- a/Sources/ProcessOut/Sources/Sessions/WebAuthentication/DefaultWebAuthenticationSession.swift
+++ b/Sources/ProcessOut/Sources/Sessions/WebAuthentication/DefaultWebAuthenticationSession.swift
@@ -33,8 +33,6 @@ final class DefaultWebAuthenticationSession:
                         url: url,
                         callbackURLScheme: callbackScheme,
                         completionHandler: { url, error in
-                            // `completionHandler` is invoked before session is dismissed, see
-                            // https://github.com/aws-amplify/amplify-swift/issues/959 for similar issue.
                             sessionProxy.invalidate()
                             if let error {
                                 continuation.resume(throwing: Self.converted(error: error))

--- a/Sources/ProcessOut/Sources/Sessions/WebAuthentication/ThrottledWebAuthenticationSessionDecorator.swift
+++ b/Sources/ProcessOut/Sources/Sessions/WebAuthentication/ThrottledWebAuthenticationSessionDecorator.swift
@@ -1,0 +1,62 @@
+//
+//  ThrottledWebAuthenticationSessionDecorator.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 09.10.2024.
+//
+
+import Foundation
+
+@MainActor
+final class ThrottledWebAuthenticationSessionDecorator: WebAuthenticationSession {
+
+    nonisolated init(session: WebAuthenticationSession) {
+        self.session = session
+        semaphore = AsyncSemaphore(value: 1)
+    }
+
+    // MARK: - WebAuthenticationSession
+
+    func authenticate(
+        using url: URL, callbackScheme: String?, additionalHeaderFields: [String: String]?
+    ) async throws -> URL {
+        do {
+            try await semaphore.waitUnlessCancelled()
+        } catch {
+            throw POFailure(message: "Authentication session was cancelled.", code: .cancelled)
+        }
+        defer {
+            lastAuthenticationTime = DispatchTime.now()
+            semaphore.signal()
+        }
+        await delayAuthenticationIfNeeded()
+        return try await self.session.authenticate(
+            using: url, callbackScheme: callbackScheme, additionalHeaderFields: additionalHeaderFields
+        )
+    }
+
+    // MARK: - Private Properties
+
+    private let session: WebAuthenticationSession
+    private let semaphore: AsyncSemaphore
+
+    private var lastAuthenticationTime: DispatchTime?
+
+    // MARK: - Private Methods
+
+    /// `ASWebAuthenticationSession`'s `completionHandler` is invoked before session is
+    /// dismissed. In attempt to workaround presentation issues sequential authentications are delayed.
+    /// See https://github.com/aws-amplify/amplify-swift/issues/959 for similar issue.
+    private func delayAuthenticationIfNeeded() async {
+        guard let lastAuthenticationTime else {
+            return
+        }
+        let elapsedTime = DispatchTime.now().uptimeNanoseconds - lastAuthenticationTime.uptimeNanoseconds
+        let expectedDelay = 1 * NSEC_PER_SEC
+        let delay = expectedDelay.subtractingReportingOverflow(elapsedTime)
+        guard !delay.overflow else {
+            return
+        }
+        try? await Task.sleep(nanoseconds: delay.partialValue)
+    }
+}

--- a/Tests/ProcessOutTests/Sources/Unit/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspensionTests.swift
+++ b/Tests/ProcessOutTests/Sources/Unit/Core/Utils/AsyncSemaphore/AsyncSemaphoreSuspensionTests.swift
@@ -1,0 +1,152 @@
+//
+//  AsyncSemaphoreSuspensionTests.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 10.10.2024.
+//
+
+@testable import ProcessOut
+import XCTest
+
+final class AsyncSemaphoreSuspensionTests: XCTestCase {
+
+    func test_resume_whenStateIsNotSet_resumesContinuation() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.resume()
+
+        // Then
+        await withUnsafeContinuation { sut.setContinuation($0) }
+    }
+
+    func test_resume_whenAlreadyResumed_resumesContinuation() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.resume()
+        sut.resume()
+
+        // Then
+        await withUnsafeContinuation { sut.setContinuation($0) }
+    }
+
+    func test_resume_whenContinuationIsSet_resumesContinuation() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+        let expectation1 = XCTestExpectation(), expectation2 = XCTestExpectation()
+
+        // When
+        Task {
+            await withUnsafeContinuation { continuation in
+                sut.setContinuation(continuation)
+                expectation1.fulfill()
+            }
+            expectation2.fulfill()
+        }
+        await fulfillment(of: [expectation1], timeout: 1)
+
+        // Then
+        sut.resume()
+        await fulfillment(of: [expectation2], timeout: 1)
+    }
+
+    func test_resume_whenStateIsNotSet_resumesThrowingContinuation() async throws {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.resume()
+
+        // Then
+        try await withUnsafeThrowingContinuation { sut.setContinuation($0) }
+    }
+
+    func test_resume_whenAlreadyResumed_resumesThrowingContinuation() async throws {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.resume()
+        sut.resume()
+
+        // Then
+        try await withUnsafeThrowingContinuation { sut.setContinuation($0) }
+    }
+
+    func test_resume_whenContinuationIsSet_resumesThrowingContinuation() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+        let expectation1 = XCTestExpectation(), expectation2 = XCTestExpectation()
+
+        // When
+        Task {
+            do {
+                try await withUnsafeThrowingContinuation { continuation in
+                    sut.setContinuation(continuation)
+                    expectation1.fulfill()
+                }
+                expectation2.fulfill()
+            } catch {
+                XCTFail("Enexpected error.")
+            }
+        }
+        await fulfillment(of: [expectation1], timeout: 1)
+
+        // Then
+        sut.resume()
+        await fulfillment(of: [expectation2], timeout: 1)
+    }
+
+    func test_cancel_whenStateIsNotSet_resumesContinuationWithError() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.cancel()
+
+        // Then
+        await assertThrowsError(
+            try await withUnsafeThrowingContinuation { sut.setContinuation($0) }, errorType: CancellationError.self
+        )
+    }
+
+    func test_cancel_whenAlreadyCancelled_resumesContinuationWithError() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+
+        // When
+        sut.cancel()
+        sut.cancel()
+
+        // Then
+        await assertThrowsError(
+            try await withUnsafeThrowingContinuation { sut.setContinuation($0) }, errorType: CancellationError.self
+        )
+    }
+
+    func test_cancel_whenContinuationIsSet_resumesContinuationWithError() async {
+        // Given
+        let sut = AsyncSemaphoreSuspension()
+        let expectation1 = XCTestExpectation(), expectation2 = XCTestExpectation()
+
+        // When
+        Task {
+            do {
+                try await withUnsafeThrowingContinuation { continuation in
+                    sut.setContinuation(continuation)
+                    expectation1.fulfill()
+                }
+            } catch {
+                expectation2.fulfill()
+            }
+        }
+        await fulfillment(of: [expectation1], timeout: 1)
+
+        // Then
+        sut.cancel()
+        await fulfillment(of: [expectation2], timeout: 1)
+    }
+}

--- a/Tests/ProcessOutTests/Sources/Unit/Core/Utils/AsyncSemaphore/AsyncSemaphoreTests.swift
+++ b/Tests/ProcessOutTests/Sources/Unit/Core/Utils/AsyncSemaphore/AsyncSemaphoreTests.swift
@@ -1,0 +1,188 @@
+//
+//  AsyncSemaphoreTests.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 10.10.2024.
+//
+
+@testable import ProcessOut
+import XCTest
+
+final class AsyncSemaphoreTests: XCTestCase {
+
+    // MARK: - Wait
+
+    func test_wait_whenInitialValueIsZero_suspends() async {
+        // Given
+        let sut = AsyncSemaphore(value: 0)
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
+
+        // When
+        Task {
+            await sut.wait()
+            expectation.fulfill()
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_wait_whenInitialValueIsGreaterThanZero_doesntSuspend() async {
+        // Given
+        let sut = AsyncSemaphore(value: 1)
+        let expectation = XCTestExpectation()
+
+        // When
+        Task {
+            await sut.wait()
+            expectation.fulfill()
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_wait_whenSemaphoreIsBlocked_suspendsSecondFunc() async {
+        // Given
+        let sut = AsyncSemaphore(value: 1)
+        let expectation1 = XCTestExpectation(), expectation2 = XCTestExpectation()
+        expectation2.isInverted = true
+
+        // When
+        Task {
+            await sut.wait()
+            expectation1.fulfill()
+            await sut.wait()
+            expectation2.fulfill()
+        }
+
+        // Then
+        await fulfillment(of: [expectation1, expectation2], timeout: 1)
+    }
+
+    // MARK: - Wait Unless Cancelled
+
+    func test_waitUnlessCancelled_whenInitialValueIsZero_suspendsAndDoesntThrow() async {
+        // Given
+        let sut = AsyncSemaphore(value: 0)
+        let expectation = XCTestExpectation()
+        expectation.isInverted = true
+
+        // When
+        Task {
+            do {
+                try await sut.waitUnlessCancelled()
+                expectation.fulfill()
+            } catch {
+                XCTFail("Unexpected error.")
+            }
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_waitUnlessCancelled_whenInitialValueIsGreaterThanZero_doesntSuspendNorThrow() async {
+        // Given
+        let sut = AsyncSemaphore(value: 1)
+        let expectation = XCTestExpectation()
+
+        // When
+        Task {
+            do {
+                try await sut.waitUnlessCancelled()
+                expectation.fulfill()
+            } catch {
+                XCTFail("Unexpected error.")
+            }
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_waitUnlessCancelled_whenSemaphoreIsBlocked_suspendsSecondFuncAndDoesntThrow() async {
+        // Given
+        let sut = AsyncSemaphore(value: 1)
+        let expectation1 = XCTestExpectation(), expectation2 = XCTestExpectation()
+        expectation2.isInverted = true
+
+        // When
+        Task {
+            do {
+                try await sut.waitUnlessCancelled()
+                expectation1.fulfill()
+                try await sut.waitUnlessCancelled()
+                expectation2.fulfill()
+            } catch {
+                XCTFail("Unexpected error.")
+            }
+        }
+
+        // Then
+        await fulfillment(of: [expectation1, expectation2], timeout: 1)
+    }
+
+    func test_waitUnlessCancelled_whenCancelledImmediately_throwsCancellationError() async {
+        // Given
+        let sut = AsyncSemaphore(value: 0)
+        let expectation = XCTestExpectation()
+
+        // When
+        let task = Task {
+            do {
+                try await sut.waitUnlessCancelled()
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+                expectation.fulfill()
+            }
+        }
+        task.cancel()
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func test_waitUnlessCancelled_whenCancelledAfterDelay_throwsCancellationError() async {
+        // Given
+        let sut = AsyncSemaphore(value: 0)
+        let expectation = XCTestExpectation()
+
+        // When
+        let task = Task {
+            do {
+                try await sut.waitUnlessCancelled()
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+                expectation.fulfill()
+            }
+        }
+        Task {
+            try await Task.sleep(for: .seconds(0.5))
+            task.cancel()
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    // MARK: - Signal
+
+    func test_signal_whenSemaphoreIsBlocked_resumesWhenSignalled() async {
+        // Given
+        let sut = AsyncSemaphore(value: 1)
+        let expectation = XCTestExpectation()
+
+        // When
+        Task {
+            await sut.wait()
+            sut.signal()
+            await sut.wait()
+            expectation.fulfill()
+        }
+
+        // Then
+        await fulfillment(of: [expectation], timeout: 1)
+    }
+}

--- a/Tests/ProcessOutTests/Sources/Unit/Sessions/WebAuthentication/ThrottledWebAuthenticationSessionDecoratorTests.swift
+++ b/Tests/ProcessOutTests/Sources/Unit/Sessions/WebAuthentication/ThrottledWebAuthenticationSessionDecoratorTests.swift
@@ -1,0 +1,58 @@
+//
+//  ThrottledWebAuthenticationSessionDecoratorTests.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 10.10.2024.
+//
+
+@testable import ProcessOut
+import XCTest
+
+final class ThrottledWebAuthenticationSessionDecoratorTests: XCTestCase {
+
+    // MARK: - Wait
+
+    func test_authenticate_allowsOneAuthenticationAtTime() async throws {
+        // Given
+        let mockSession = MockWebAuthenticationSession()
+        mockSession.authenticateFromClosure = { _, _, _ in
+            try await Task.sleep(for: .seconds(5))
+            return URL(string: "response.com")!
+        }
+        let sut = ThrottledWebAuthenticationSessionDecorator(session: mockSession)
+
+        // When
+        Task {
+            _ = try await sut.authenticate(using: URL(string: "request1.com")!)
+        }
+        Task {
+            _ = try await sut.authenticate(using: URL(string: "request2.com")!)
+        }
+        try await Task.sleep(for: .seconds(1))
+
+        // Then
+        XCTAssertEqual(mockSession.authenticateCallsCount, 1)
+    }
+
+    func test_authenticate_throttlesAuthentications() async throws {
+        var lastAuthenticationStartTime: DispatchTime?
+
+        // Given
+        let mockSession = MockWebAuthenticationSession()
+        mockSession.authenticateFromClosure = { _, _, _ in
+            // Then
+            if let lastAuthenticationStartTime {
+                let delay = Int(DispatchTime.now().uptimeNanoseconds - lastAuthenticationStartTime.uptimeNanoseconds)
+                let expectedDelay = 1_000_000_000, tolerance = 500_000_000 // 1 and 0.5 seconds respectfully
+                XCTAssertTrue(abs(delay - expectedDelay) <= tolerance)
+            }
+            lastAuthenticationStartTime = DispatchTime.now()
+            return URL(string: "response.com")!
+        }
+        let sut = ThrottledWebAuthenticationSessionDecorator(session: mockSession)
+
+        // When
+        _ = try await sut.authenticate(using: URL(string: "request1.com")!)
+        _ = try await sut.authenticate(using: URL(string: "request2.com")!)
+    }
+}


### PR DESCRIPTION
## Description
The `ASWebAuthenticationSession` triggers its completion handler before the dismissal process fully completes. To prevent issues with subsequent authentications, workaround that introduces a 1-second delay before initiating the next authentication session was added.

Additionally, the `ThrottledWebAuthenticationSessionDecorator` enforces that only one authentication operation can be active at a time, ensuring proper sequencing and avoiding overlapping requests.

## Jira Issue
\-
