### PR TITLE
fix(ad-hoc): Checkout 3DS service backward compatibility

### DIFF
--- a/Sources/ProcessOutCheckout3DS/Sources/Builder/POCheckout3DSServiceBuilder.swift
+++ b/Sources/ProcessOutCheckout3DS/Sources/Builder/POCheckout3DSServiceBuilder.swift
@@ -37,8 +37,8 @@ public final class POCheckout3DSServiceBuilder {
     }
 
     /// Creates service instance.
-    public func build() -> PO3DS2Service {
-        POCheckout3DSService(delegate: delegate, environment: environment)
+    public func build() -> PO3DSService {
+        ThreeDSServiceAdapter(service: POCheckout3DSService(delegate: delegate, environment: environment))
     }
 
     // MARK: - Private Properties

--- a/Sources/ProcessOutCheckout3DS/Sources/Builder/ThreeDSServiceAdapter.swift
+++ b/Sources/ProcessOutCheckout3DS/Sources/Builder/ThreeDSServiceAdapter.swift
@@ -1,0 +1,56 @@
+//
+//  ThreeDSServiceAdapter.swift
+//  ProcessOutCheckout3DS
+//
+//  Created by Andrii Vysotskyi on 13.11.2024.
+//
+
+import ProcessOut
+
+@available(*, deprecated)
+final class ThreeDSServiceAdapter: PO3DSService {
+
+    init(service: PO3DS2Service) {
+        self.service = service
+    }
+
+    // MARK: - PO3DSService
+
+    func authenticationRequest(
+        configuration: PO3DS2Configuration,
+        completion: @escaping (Result<PO3DS2AuthenticationRequestParameters, POFailure>) -> Void
+    ) {
+        invoke(completion: completion) { [service] in
+            try await service.authenticationRequestParameters(configuration: configuration)
+        }
+    }
+
+    func handle(challenge: PO3DS2ChallengeParameters, completion: @escaping (Result<Bool, POFailure>) -> Void) {
+        invoke(completion: completion) { [service] in
+            try await service.performChallenge(with: challenge).transactionStatus == "Y"
+        }
+    }
+
+    // MARK: - Private Properties
+
+    private let service: PO3DS2Service
+
+    // MARK: - Private Methods
+
+    private func invoke<T>(
+        completion: @escaping (Result<T, POFailure>) -> Void,
+        after operation: @escaping @isolated(any) () async throws -> T
+    ) {
+        Task { @MainActor in
+            do {
+                let returnValue = try await operation()
+                completion(.success(returnValue))
+            } catch let failure as POFailure {
+                completion(.failure(failure))
+            } catch {
+                let failure = POFailure(message: "Something went wrong.", code: .internal(.mobile), underlyingError: error) // swiftlint:disable:this line_length
+                completion(.failure(failure))
+            }
+        }
+    }
+}

--- a/Sources/ProcessOutCheckout3DS/Sources/Builder/ThreeDSServiceAdapter.swift
+++ b/Sources/ProcessOutCheckout3DS/Sources/Builder/ThreeDSServiceAdapter.swift
@@ -31,6 +31,10 @@ final class ThreeDSServiceAdapter: PO3DSService {
         }
     }
 
+    func clean() async {
+        await service.clean()
+    }
+
     // MARK: - Private Properties
 
     private let service: PO3DS2Service


### PR DESCRIPTION
## Description
`POCheckout3DSServiceBuilder/build()` method's return type was changed from `PO3DSService` to `PO3DS2Service` which was not backward compatible.

## Jira Issue
\-
