### PR TITLE
fix(ad-hoc): use brand color to style express payment button

### DIFF
--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/View/DynamicCheckoutExpressPaymentView.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/View/DynamicCheckoutExpressPaymentView.swift
@@ -31,6 +31,7 @@ struct DynamicCheckoutExpressPaymentView: View {
         .buttonStyle(POAnyButtonStyle(erasing: style.expressPaymentButtonStyle))
         .disabled(item.isLoading)
         .buttonLoading(item.isLoading)
+        .buttonBrandColor(item.brandColor)
         .fontNumberSpacing(.monospaced)
     }
 


### PR DESCRIPTION
## Description
<img src=https://github.com/user-attachments/assets/064fa9d0-e0ef-4e40-862f-260f2144604f width=200/>

## Jira Issue
N/A
