### PR TITLE
fix(POM-446): web authentication session crash

### DIFF
--- a/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
+++ b/Sources/ProcessOut/Sources/Generated/Sourcery+Generated.swift
@@ -1,4 +1,4 @@
-// Generated using Sourcery 2.2.5 — https://github.com/krzysztofzablocki/Sourcery
+// Generated using Sourcery 2.2.6 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 
 import Foundation

--- a/Sources/ProcessOut/Sources/Sessions/ApplePay/ApplePayAuthorizationSessionCoordinator.swift
+++ b/Sources/ProcessOut/Sources/Sessions/ApplePay/ApplePayAuthorizationSessionCoordinator.swift
@@ -18,7 +18,7 @@ final class ApplePayAuthorizationSessionCoordinator: NSObject, PKPaymentAuthoriz
     /// Payment information.
     var payment: PKPayment?
 
-    func setContinuation(continuation: CheckedContinuation<Void, Never>) {
+    func setContinuation(_ continuation: CheckedContinuation<Void, Never>) {
         switch state {
         case .processing:
             preconditionFailure("Continuation is already set.")

--- a/Sources/ProcessOut/Sources/Sessions/ApplePay/DefaultApplePayAuthorizationSession.swift
+++ b/Sources/ProcessOut/Sources/Sessions/ApplePay/DefaultApplePayAuthorizationSession.swift
@@ -20,7 +20,7 @@ final class DefaultApplePayAuthorizationSession: ApplePayAuthorizationSession {
         }
         await withTaskCancellationHandler {
             await withCheckedContinuation { continuation in
-                coordinator.setContinuation(continuation: continuation)
+                coordinator.setContinuation(continuation)
             }
         } onCancel: {
             Task { @MainActor in


### PR DESCRIPTION
## Description
* Ensure `DefaultWebAuthenticationSession` resumes continuation exactly once per authentication attempt to prevent system crash caused by assertion.
* Ensure session UI is properly dismissed if authentication is programmatically cancelled immediately after start (and shortly after).

## Jira Issue
https://checkout.atlassian.net/browse/POM-446
