### PR TITLE
fix(ad-hoc): authentication session start

### DIFF
--- a/Sources/ProcessOut/Sources/Sessions/WebAuthentication/DefaultWebAuthenticationSession.swift
+++ b/Sources/ProcessOut/Sources/Sessions/WebAuthentication/DefaultWebAuthenticationSession.swift
@@ -48,9 +48,19 @@ final class DefaultWebAuthenticationSession:
     nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         MainActor.assumeIsolated {
             let application = UIApplication.shared
-            let scene = application.connectedScenes.first { $0 is UIWindowScene } as? UIWindowScene
-            let window = scene?.windows.first(where: \.isKeyWindow)
-            return window ?? ASPresentationAnchor()
+            for scene in application.connectedScenes {
+                // The scene of returned presentation anchor is expected to be in
+                // foreground active state otherwise authentication start fails.
+                if scene.activationState != .foregroundActive {
+                    continue
+                }
+                let windowScene = scene as? UIWindowScene
+                guard let window = windowScene?.windows.first(where: \.isKeyWindow) else {
+                    continue
+                }
+                return window
+            }
+            return ASPresentationAnchor()
         }
     }
 


### PR DESCRIPTION
## Description
If a session is started with a presentation anchor whose scene is not in the foreground active state, the session fails with the following error:

`The UIWindowScene for the returned window was not in the foreground active state.`

## Solution
Ensure that only scenes with the foregroundActive state are used, or return a new presentation anchor without an associated scene.