### PR TITLE
fix(ad-hoc): fix card scanner focus

### DIFF
--- a/Sources/ProcessOutUI/Sources/Modules/CardScanner/Sessions/Camera/DefaultCameraSession.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardScanner/Sessions/Camera/DefaultCameraSession.swift
@@ -200,7 +200,14 @@ actor DefaultCameraSession:
         guard activeVideoInput == nil else {
             return true // Already configured
         }
-        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back) else {
+        let discoverySession = AVCaptureDevice.DiscoverySession(
+            deviceTypes: [
+                .builtInTripleCamera, .builtInDualWideCamera, .builtInUltraWideCamera, .builtInWideAngleCamera
+            ],
+            mediaType: .video,
+            position: .back
+        )
+        guard let device = discoverySession.devices.first else {
             return false
         }
         let videoInput: AVCaptureDeviceInput
@@ -241,6 +248,9 @@ actor DefaultCameraSession:
         }
         if device.isLowLightBoostSupported {
             device.automaticallyEnablesLowLightBoostWhenAvailable = true
+        }
+        if device.isAutoFocusRangeRestrictionSupported {
+            device.autoFocusRangeRestriction = .near
         }
         device.unlockForConfiguration()
     }

--- a/Sources/ProcessOutUI/Sources/Modules/CardScanner/Sessions/CardRecognition/CardRecognitionSession.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardScanner/Sessions/CardRecognition/CardRecognitionSession.swift
@@ -91,9 +91,6 @@ actor CardRecognitionSession: CameraSessionDelegate {
     private func recognizedTexts(
         for textObservations: [VNRecognizedTextObservation]?, inside rectangleObservation: VNRectangleObservation?
     ) -> [VNRecognizedText] {
-        guard let rectangleObservation else {
-            return [] // Abort recognition if card shape is not detected
-        }
         let candidates = textObservations?
             .filter { textObservation in
                 shouldInclude(textObservation: textObservation, cardRectangleObservation: rectangleObservation)
@@ -109,11 +106,15 @@ actor CardRecognitionSession: CameraSessionDelegate {
     }
 
     private func shouldInclude(
-        textObservation: VNRecognizedTextObservation, cardRectangleObservation: VNRectangleObservation
+        textObservation: VNRecognizedTextObservation, cardRectangleObservation: VNRectangleObservation?
     ) -> Bool {
         guard textObservation.confidence > Constants.minimumConfidence else {
             return false
         }
+        guard let cardRectangleObservation else {
+            return true
+        }
+        // Only include text observations within detected card shape if any.
         return textObservation.boundingBox.intersects(cardRectangleObservation.boundingBox)
     }
 


### PR DESCRIPTION
## Description
* Restrict focus range.
* Prefer camera device with close proximity capability.
* Make card shape recognition less strict.