### PR TITLE
feat(ad-hoc): support library evolution

### DIFF
--- a/Sources/ProcessOutCoreUI/Sources/Core/SwiftUI+Extensions/Group+Subviews.swift
+++ b/Sources/ProcessOutCoreUI/Sources/Core/SwiftUI+Extensions/Group+Subviews.swift
@@ -22,14 +22,17 @@ extension Group {
 
 @_spi(PO)
 @MainActor
+@frozen
 public struct POSubviewsTransformView<Subviews: View, Content: View>: View {
 
+    @inlinable
     init(subviews: Subviews, @ViewBuilder transform: @escaping (_VariadicView.Children) -> Content) {
         tree = .init(.init(transform: transform)) { subviews }
     }
 
     // MARK: - View
 
+    @inlinable
     public var body: some View {
         tree
     }
@@ -37,12 +40,13 @@ public struct POSubviewsTransformView<Subviews: View, Content: View>: View {
     // MARK: - Private Properties
 
     @usableFromInline
-    let tree: _VariadicView.Tree<SubviewsTransformViewRoot<Content>, Subviews>
+    let tree: _VariadicView.Tree<POSubviewsTransformViewRoot<Content>, Subviews>
 }
 
+@_spi(PO)
 @MainActor
-@usableFromInline
-struct SubviewsTransformViewRoot<Content: View>: _VariadicView_MultiViewRoot {
+@frozen
+public struct POSubviewsTransformViewRoot<Content: View>: _VariadicView_MultiViewRoot {
 
     @inlinable
     init(transform: @escaping (_VariadicView.Children) -> Content) {
@@ -51,8 +55,8 @@ struct SubviewsTransformViewRoot<Content: View>: _VariadicView_MultiViewRoot {
 
     // MARK: - _VariadicView_MultiViewRoot
 
-    @usableFromInline
-    func body(children: _VariadicView.Children) -> Content {
+    @inlinable
+    public func body(children: _VariadicView.Children) -> Content {
         transform(children)
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -433,6 +433,8 @@ final class DefaultCardTokenizationInteractor:
             return false
         case .full:
             return true
+        @unknown default:
+            return true // Collect all possible fields
         }
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -471,7 +471,7 @@ final class DynamicCheckoutDefaultInteractor:
             startNativeAlternativePayment(method: method, startedState: newStartedState)
         case .customerToken(let method):
             startCustomerTokenPayment(method: method, startedState: newStartedState)
-        case .unknown:
+        default:
             logger.error("Attempted to start unknown payment method.")
         }
     }

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/ViewModel/DefaultDynamicCheckoutViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/ViewModel/DefaultDynamicCheckoutViewModel.swift
@@ -642,7 +642,9 @@ final class DefaultDynamicCheckoutViewModel: ViewModel {
         case .customerToken(let method):
             return method.flow == .express
         case .unknown:
-            preconditionFailure("Unexpected payment method.")
+            return false
+        @unknown default:
+            return false
         }
     }
 
@@ -657,6 +659,8 @@ final class DefaultDynamicCheckoutViewModel: ViewModel {
         case .customerToken(let paymentMethod):
             return paymentMethod.configuration.redirectUrl != nil
         case .applePay, .unknown:
+            return nil
+        @unknown default:
             return nil
         }
     }

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,7 @@ settings:
   LOCALIZED_STRING_MACRO_NAMES: "$(inherited) POStringResource"
   LOCALIZATION_PREFERS_STRING_CATALOGS: true
   ASSETCATALOG_COMPILER_GENERATE_ASSET_SYMBOLS: false
+  BUILD_LIBRARY_FOR_DISTRIBUTION: true
 options:
   transitivelyLinkDependencies: true
 packages:


### PR DESCRIPTION
## Description

- Ensure that the library can be built with evolution mode enabled.

  The init method of `SubviewsTransformViewRoot` was marked as @inlinable, which is [incompatible](https://github.com/swiftlang/swift/issues/62507) with evolution mode since the struct is not frozen.

- Enable evolution mode for the development project `ProcessOut.xcodeproj` to prevent future issues.

- Address warnings related to evolution mode.

## Jira Issue
\-
