### PR TITLE
feat(POM-475): support card eligibility evaluation during tokenization

### DIFF
--- a/Sources/ProcessOut/Sources/Repositories/Cards/Responses/POCardIssuerInformation.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Cards/Responses/POCardIssuerInformation.swift
@@ -28,6 +28,9 @@ public struct POCardIssuerInformation: Codable, Sendable {
     /// Card category.
     public let category: String?
 
+    /// Issuer country code.
+    public let country: String?
+
     @_spi(PO)
     public init(
         scheme: POCardScheme,
@@ -35,7 +38,8 @@ public struct POCardIssuerInformation: Codable, Sendable {
         type: String? = nil,
         bankName: String? = nil,
         brand: String? = nil,
-        category: String? = nil
+        category: String? = nil,
+        country: String? = nil
     ) {
         self._scheme = .init(wrappedValue: scheme.rawValue)
         self._coScheme = .init(wrappedValue: coScheme?.rawValue)
@@ -43,5 +47,6 @@ public struct POCardIssuerInformation: Codable, Sendable {
         self.bankName = bankName
         self.brand = brand
         self.category = category
+        self.country = country
     }
 }

--- a/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailure+Legacy.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailure+Legacy.swift
@@ -410,6 +410,7 @@ extension POFailure {
         underlyingError: Error? = nil
     ) {
         self.message = message
+        self.errorDescription = nil
         self.failureCode = .init(rawValue: code.rawValue)
         self.invalidFields = invalidFields
         self.underlyingError = underlyingError

--- a/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailure.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailure.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Information about an error that occurred.
-public struct POFailure: Error {
+public struct POFailure: LocalizedError {
 
     public struct InvalidField: Codable, Sendable {
 
@@ -28,6 +28,9 @@ public struct POFailure: Error {
     /// Failure message. Not intented to be used as a user facing string.
     public let message: String?
 
+    /// Localized error description if any.
+    public let errorDescription: String?
+
     /// Failure code.
     public let failureCode: POFailureCode
 
@@ -40,11 +43,13 @@ public struct POFailure: Error {
     /// Creates failure instance.
     public init(
         message: String? = nil,
+        errorDescription: String? = nil,
         code: POFailureCode,
         invalidFields: [InvalidField]? = nil,
         underlyingError: Error? = nil
     ) {
         self.message = message
+        self.errorDescription = errorDescription
         self.failureCode = code
         self.invalidFields = invalidFields
         self.underlyingError = underlyingError
@@ -56,6 +61,7 @@ extension POFailure: Codable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         message = try container.decodeIfPresent(String.self, forKey: .message)
+        errorDescription = nil
         failureCode = try container.decode(POFailureCode.self, forKey: .code)
         invalidFields = try container.decodeIfPresent([InvalidField].self, forKey: .invalidFields)
         underlyingError = nil

--- a/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailureCode.swift
+++ b/Sources/ProcessOut/Sources/Repositories/Shared/Responses/Failure/POFailureCode.swift
@@ -223,7 +223,7 @@ extension POFailureCode {
         /// The card was a test card and can't be used to process live transactions.
         public static let test = POFailureCode(rawValue: "card.test")
 
-        /// The card was blacklisted from the payment provider
+        /// The card was blacklisted from the payment provider.
         public static let blacklisted = POFailureCode(rawValue: "card.blacklisted")
     }
 

--- a/Sources/ProcessOutCoreUI/Sources/DesignSystem/ContentUnavailableView/Style/System/POSystemContentUnavailableViewStyle.swift
+++ b/Sources/ProcessOutCoreUI/Sources/DesignSystem/ContentUnavailableView/Style/System/POSystemContentUnavailableViewStyle.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-/// The content unavailable view style that uses system ``ContentUnavailableView``.
+/// The content unavailable view style that uses system `ContentUnavailableView`.
 @available(iOS 17, *)
 public struct POSystemContentUnavailableViewStyle: POContentUnavailableViewStyle {
 
@@ -23,7 +23,7 @@ public struct POSystemContentUnavailableViewStyle: POContentUnavailableViewStyle
 @available(iOS 17, *)
 extension POContentUnavailableViewStyle where Self == POSystemContentUnavailableViewStyle {
 
-    /// The content unavailable view style that uses system ``ContentUnavailableView``.
+    /// The content unavailable view style that uses system `ContentUnavailableView`.
     public static var system: POSystemContentUnavailableViewStyle {
         POSystemContentUnavailableViewStyle()
     }

--- a/Sources/ProcessOutUI/ProcessOutUI.docc/ProcessOutUI.md
+++ b/Sources/ProcessOutUI/ProcessOutUI.docc/ProcessOutUI.md
@@ -23,6 +23,8 @@
 - ``POCardTokenizationConfiguration``
 - ``POBillingAddressConfiguration``
 - ``POCardTokenizationDelegate``
+- ``POCardTokenizationEligibilityEvaluation``
+- ``POCardTokenizationEligibilityRequest``
 - ``POCardTokenizationEvent``
 
 ### Card Update
@@ -48,13 +50,6 @@
 - ``PODefaultCardScannerStyle``
 - ``SwiftUICore/EnvironmentValues/cardScannerStyle``
 - ``SwiftUICore/View/cardScannerStyle(_:)``
-
-### Alternative Payment Method
-
-- ``SafariServices/SFSafariViewController/init(request:returnUrl:safariConfiguration:completion:)``
-- ``SafariServices/SFSafariViewController/init(alternativePaymentMethodUrl:returnUrl:safariConfiguration:completion:)``
-- ``POWebAuthenticationSession/init(alternativePaymentMethodUrl:returnUrl:completion:)``
-- ``POWebAuthenticationSession/init(request:returnUrl:completion:)``
 
 ### Native Alternative Payment Method
 
@@ -101,6 +96,13 @@
 ### Utils
 
 - ``POConfirmationDialogConfiguration``
+
+### Alternative Payment Method
+
+- ``SafariServices/SFSafariViewController/init(request:returnUrl:safariConfiguration:completion:)``
+- ``SafariServices/SFSafariViewController/init(alternativePaymentMethodUrl:returnUrl:safariConfiguration:completion:)``
+- ``POWebAuthenticationSession/init(alternativePaymentMethodUrl:returnUrl:completion:)``
+- ``POWebAuthenticationSession/init(request:returnUrl:completion:)``
 
 ### Apple Pay
 

--- a/Sources/ProcessOutUI/Resources/Localizable.xcstrings
+++ b/Sources/ProcessOutUI/Resources/Localizable.xcstrings
@@ -1259,6 +1259,9 @@
         }
       }
     },
+    "card-tokenization.error.eligibility" : {
+
+    },
     "card-tokenization.error.generic" : {
       "localizations" : {
         "ar" : {

--- a/Sources/ProcessOutUI/Resources/Localizable.xcstrings
+++ b/Sources/ProcessOutUI/Resources/Localizable.xcstrings
@@ -1260,7 +1260,38 @@
       }
     },
     "card-tokenization.error.eligibility" : {
-
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا يمكننا قبول هذه البطاقة. يرجى المحاولة باستخدام بطاقة أخرى."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We can’t accept this card. Please try a different one."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nous ne pouvons pas accepter cette carte. Veuillez en essayer une autre."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie możemy zaakceptować tej karty. Spróbuj użyć innej."
+          }
+        },
+        "pt-PT" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Não podemos aceitar este cartão. Por favor, tente com outro."
+          }
+        }
+      }
     },
     "card-tokenization.error.generic" : {
       "localizations" : {

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Configuration/POCardTokenizationConfiguration.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Configuration/POCardTokenizationConfiguration.swift
@@ -34,7 +34,7 @@ public struct POCardTokenizationConfiguration {
         /// Default address information.
         public let defaultAddress: POContact?
 
-        /// Whether the values included in ``POBillingAddressConfiguration/defaultAddress`` should be attached to the
+        /// Whether the values included in ``BillingAddress/defaultAddress`` should be attached to the
         /// card, this includes fields that aren't displayed in the form.
         ///
         /// If `false` (the default), those values will only be used to prefill the corresponding fields in the form.

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
@@ -18,11 +18,12 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     /// Allows delegate to additionally process tokenized card before ending module's lifecycle. For example
     /// it is possible to authorize an invoice or assign customer token. Default implementation does nothing.
     ///
+    /// Your implementation may throw a `POFailure` containing a localized `errorDescription` that will be
+    /// shown directly to the user.
+    ///
     /// - Parameters:
     ///   - card: Tokenized card instance.
     ///   - shouldSaveCard: A Boolean value indicating whether the user has requested card to be saved.
-    ///
-    /// - NOTE: When possible please prefer throwing `POFailure` instead of other error types.
     @MainActor
     func cardTokenization(didTokenizeCard card: POCard, shouldSaveCard: Bool) async throws
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
@@ -26,13 +26,11 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     @MainActor
     func cardTokenization(didTokenizeCard card: POCard, shouldSaveCard: Bool) async throws
 
-    /// Allows delegate to additionally process tokenized card before ending module's lifecycle. For example
-    /// it is possible to authorize an invoice or assign customer token. Default implementation does nothing.
-    ///
-    /// - NOTE: When possible please prefer throwing `POFailure` instead of other error types.
-    @available(*, deprecated, message: "Implement cardTokenization(didTokenizeCard:save:) method instead.")
+    /// Asks the delegate to evaluate whether a card is eligible for tokenization based on its issuer information.
     @MainActor
-    func processTokenizedCard(card: POCard) async throws
+    func cardTokenization(
+        evaluateEligibilityWith request: POCardTokenizationEligibilityRequest
+    ) -> POCardTokenizationEligibilityEvaluation
 
     /// Allows to choose preferred scheme that will be selected by default based on issuer information. Default
     /// implementation returns primary scheme.
@@ -43,6 +41,16 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     /// Default implementation returns `true`.
     @MainActor
     func shouldContinueTokenization(after failure: POFailure) -> Bool
+
+    // MARK: - Deprecations
+
+    /// Allows delegate to additionally process tokenized card before ending module's lifecycle. For example
+    /// it is possible to authorize an invoice or assign customer token. Default implementation does nothing.
+    ///
+    /// - NOTE: When possible please prefer throwing `POFailure` instead of other error types.
+    @available(*, deprecated, message: "Implement cardTokenization(didTokenizeCard:save:) method instead.")
+    @MainActor
+    func processTokenizedCard(card: POCard) async throws
 
     // MARK: - Card Scanning
 
@@ -69,6 +77,13 @@ extension POCardTokenizationDelegate {
     @MainActor
     public func processTokenizedCard(card: POCard) async throws {
         // Ignored
+    }
+
+    @MainActor
+    public func cardTokenization(
+        evaluateEligibilityWith request: POCardTokenizationEligibilityRequest
+    ) -> POCardTokenizationEligibilityEvaluation {
+        .eligible()
     }
 
     @MainActor

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
@@ -30,7 +30,7 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     @MainActor
     func cardTokenization(
         evaluateEligibilityWith request: POCardTokenizationEligibilityRequest
-    ) -> POCardTokenizationEligibilityEvaluation
+    ) async -> POCardTokenizationEligibilityEvaluation
 
     /// Allows to choose preferred scheme that will be selected by default based on issuer information. Default
     /// implementation uses primary scheme.
@@ -92,7 +92,7 @@ extension POCardTokenizationDelegate {
     @MainActor
     public func cardTokenization(
         evaluateEligibilityWith request: POCardTokenizationEligibilityRequest
-    ) -> POCardTokenizationEligibilityEvaluation {
+    ) async -> POCardTokenizationEligibilityEvaluation {
         .eligible()
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
@@ -33,9 +33,9 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     ) -> POCardTokenizationEligibilityEvaluation
 
     /// Allows to choose preferred scheme that will be selected by default based on issuer information. Default
-    /// implementation returns primary scheme.
+    /// implementation uses primary scheme.
     @MainActor
-    func preferredScheme(issuerInformation: POCardIssuerInformation) -> String?
+    func cardTokenization(preferredSchemeWith issuerInformation: POCardIssuerInformation) -> POCardScheme?
 
     /// Asks delegate whether user should be allowed to continue after failure or module should complete.
     /// Default implementation returns `true`.
@@ -43,6 +43,12 @@ public protocol POCardTokenizationDelegate: AnyObject, Sendable {
     func shouldContinueTokenization(after failure: POFailure) -> Bool
 
     // MARK: - Deprecations
+
+    /// Allows to choose preferred scheme that will be selected by default based on issuer information. Default
+    /// implementation uses primary scheme.
+    @available(*, deprecated, message: "Implement cardTokenization(preferredSchemeWith:) method instead.")
+    @MainActor
+    func preferredScheme(issuerInformation: POCardIssuerInformation) -> String?
 
     /// Allows delegate to additionally process tokenized card before ending module's lifecycle. For example
     /// it is possible to authorize an invoice or assign customer token. Default implementation does nothing.
@@ -67,7 +73,11 @@ extension POCardTokenizationDelegate {
         // Ignored
     }
 
-    @available(*, deprecated) // Silences deprecation warning.
+    @MainActor
+    public func cardTokenization(preferredSchemeWith issuerInformation: POCardIssuerInformation) -> POCardScheme? {
+        preferredScheme(issuerInformation: issuerInformation).map(POCardScheme.init)
+    }
+
     @MainActor
     public func cardTokenization(didTokenizeCard card: POCard, shouldSaveCard: Bool) async throws {
         try await processTokenizedCard(card: card)

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationDelegate.swift
@@ -59,9 +59,10 @@ extension POCardTokenizationDelegate {
         // Ignored
     }
 
+    @available(*, deprecated) // Silences deprecation warning.
     @MainActor
     public func cardTokenization(didTokenizeCard card: POCard, shouldSaveCard: Bool) async throws {
-        // Ignored
+        try await processTokenizedCard(card: card)
     }
 
     @available(*, deprecated, message: "Implement cardTokenization(didTokenizeCard:save:) method instead.")

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
@@ -7,22 +7,25 @@
 
 import ProcessOut
 
+/// Represents the eligibility evaluation of a card for tokenization.
 public struct POCardTokenizationEligibilityEvaluation: Sendable {
 
-    enum Eligibility {
-        case notEligible(POFailure?), eligible(schemes: Set<POCardScheme>?)
+    enum RawValue: Sendable {
+        case notEligible(POFailure?), eligible(scheme: POCardScheme?)
     }
 
-    let eligibility: Eligibility
+    let rawValue: RawValue
 }
 
 extension POCardTokenizationEligibilityEvaluation {
 
+    /// Returns an instance indicating that the card is not eligible, with optional failure details.
     public static func notEligible(failure: POFailure?) -> Self {
-        .init(eligibility: .notEligible(failure))
+        .init(rawValue: .notEligible(failure))
     }
 
-    public static func eligible(schemes: Set<POCardScheme>? = nil) -> Self {
-        .init(eligibility: .eligible(schemes: schemes))
+    /// Returns an instance indicating that the card is eligible, optionally restricted to a specific card scheme.
+    public static func eligible(scheme: POCardScheme? = nil) -> Self {
+        .init(rawValue: .eligible(scheme: scheme))
     }
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
@@ -1,0 +1,28 @@
+//
+//  POCardTokenizationEligibilityEvaluation.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 16.04.2025.
+//
+
+import ProcessOut
+
+public struct POCardTokenizationEligibilityEvaluation: Sendable {
+
+    enum Eligibility {
+        case notEligible(POFailure), eligible(schemes: Set<POCardScheme>?)
+    }
+
+    let eligibility: Eligibility
+}
+
+extension POCardTokenizationEligibilityEvaluation {
+
+    public static func notEligible(failure: POFailure) -> Self {
+        .init(eligibility: .notEligible(failure))
+    }
+
+    public static func eligible(schemes: Set<POCardScheme>? = nil) -> Self {
+        .init(eligibility: .eligible(schemes: schemes))
+    }
+}

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
@@ -20,6 +20,8 @@ public struct POCardTokenizationEligibilityEvaluation: Sendable {
 extension POCardTokenizationEligibilityEvaluation {
 
     /// Returns an instance indicating that the card is not eligible, with optional failure details.
+    ///
+    /// You may provide a ``POFailure`` containing a localized `errorDescription` that will be shown directly to the user.
     public static func notEligible(failure: POFailure? = nil) -> Self {
         .init(rawValue: .notEligible(failure))
     }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
@@ -20,7 +20,7 @@ public struct POCardTokenizationEligibilityEvaluation: Sendable {
 extension POCardTokenizationEligibilityEvaluation {
 
     /// Returns an instance indicating that the card is not eligible, with optional failure details.
-    public static func notEligible(failure: POFailure?) -> Self {
+    public static func notEligible(failure: POFailure? = nil) -> Self {
         .init(rawValue: .notEligible(failure))
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityEvaluation.swift
@@ -10,7 +10,7 @@ import ProcessOut
 public struct POCardTokenizationEligibilityEvaluation: Sendable {
 
     enum Eligibility {
-        case notEligible(POFailure), eligible(schemes: Set<POCardScheme>?)
+        case notEligible(POFailure?), eligible(schemes: Set<POCardScheme>?)
     }
 
     let eligibility: Eligibility
@@ -18,7 +18,7 @@ public struct POCardTokenizationEligibilityEvaluation: Sendable {
 
 extension POCardTokenizationEligibilityEvaluation {
 
-    public static func notEligible(failure: POFailure) -> Self {
+    public static func notEligible(failure: POFailure?) -> Self {
         .init(eligibility: .notEligible(failure))
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
@@ -10,7 +10,7 @@ import ProcessOut
 public struct POCardTokenizationEligibilityRequest: Sendable {
 
     /// Card's issuer identification number.
-    public let partialIin: String
+    public let iin: String
 
     /// Resolved issuer information.
     public let issuerInformation: POCardIssuerInformation?

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
@@ -7,6 +7,8 @@
 
 import ProcessOut
 
+/// Represents a request to evaluate whether a card is eligible for tokenization
+/// based on its issuer information.
 public struct POCardTokenizationEligibilityRequest: Sendable {
 
     /// Card's issuer identification number.

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
@@ -1,0 +1,17 @@
+//
+//  POCardTokenizationEligibilityRequest.swift
+//  ProcessOut
+//
+//  Created by Andrii Vysotskyi on 16.04.2025.
+//
+
+import ProcessOut
+
+public struct POCardTokenizationEligibilityRequest: Sendable {
+
+    /// Card's issuer identification number.
+    public let partialIin: String
+
+    /// Resolved issuer information.
+    public let issuerInformation: POCardIssuerInformation?
+}

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Delegate/POCardTokenizationEligibilityRequest.swift
@@ -13,5 +13,5 @@ public struct POCardTokenizationEligibilityRequest: Sendable {
     public let iin: String
 
     /// Resolved issuer information.
-    public let issuerInformation: POCardIssuerInformation?
+    public let issuerInformation: POCardIssuerInformation
 }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -124,7 +124,7 @@ enum CardTokenizationInteractorState {
         var preferredScheme: POCardScheme?
 
         /// Card eligibility.
-        var eligibility: POCardTokenizationEligibilityEvaluation.Eligibility?
+        var eligibility: POCardTokenizationEligibilityEvaluation.RawValue?
     }
 
     enum ValueUpdate<T> {
@@ -204,8 +204,9 @@ extension CardTokenizationInteractorState.CardInformation {
         switch eligibility {
         case .notEligible:
             return []
-        case .eligible(let eligibleSchemes?):
-            return schemes.filter(eligibleSchemes.contains)
+        case .eligible(let eligibleScheme?):
+            precondition(schemes.contains(eligibleScheme))
+            return [eligibleScheme]
         case .eligible:
             break
         case nil:

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -217,8 +217,7 @@ extension CardTokenizationInteractorState.CardInformation {
         switch eligibility {
         case .notEligible:
             return []
-        case .eligible(let eligibleScheme?):
-            precondition(schemes.contains(eligibleScheme))
+        case .eligible(let eligibleScheme?) where schemes.contains(eligibleScheme):
             return [eligibleScheme]
         case .eligible:
             break

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -50,6 +50,15 @@ enum CardTokenizationInteractorState {
         let task: Task<Void, Never>
     }
 
+    struct EvaluatingEligibility {
+
+        /// Started state snapshot.
+        let snapshot: Started
+
+        /// Evaluation task.
+        let task: Task<Void, Never>
+    }
+
     struct AddressParameters {
 
         /// Billing address country.
@@ -142,6 +151,10 @@ enum CardTokenizationInteractorState {
 
     /// Interactor has started and is ready.
     case started(Started)
+
+    /// Tokenization was requested before card eligibility was determined, so now
+    /// it's being evaluated explicitly.
+    case evaluatingEligibility(EvaluatingEligibility)
 
     /// Card information is currently being tokenized.
     case tokenizing(Tokenizing)

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -10,6 +10,10 @@ import ProcessOut
 
 enum CardTokenizationInteractorState {
 
+    enum ParameterIssue: Hashable {
+        case validation, eligibility
+    }
+
     struct Started {
 
         /// Number of the card.
@@ -79,7 +83,12 @@ enum CardTokenizationInteractorState {
         var value: String = ""
 
         /// Indicates whether parameter is valid.
-        var isValid = true
+        var isValid: Bool {
+            issues.isEmpty
+        }
+
+        /// Parameter issues.
+        var issues: Set<ParameterIssue> = []
 
         /// Boolean flag indicating whether parameter should be collected.
         var shouldCollect = true // todo(andrii-vysotskyi): consider migrating to optional parameters

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/CardTokenizationInteractorState.swift
@@ -24,6 +24,9 @@ enum CardTokenizationInteractorState {
         /// Name of cardholder.
         var cardholderName: Parameter
 
+        /// Preliminary card scheme not yet confirmed by API.
+        var preliminaryScheme: POCardScheme?
+
         /// Card issuer information based on number.
         var issuerInformation: POCardIssuerInformation?
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -148,9 +148,10 @@ final class DefaultCardTokenizationInteractor:
         logger.debug("Will tokenize card")
         delegate?.cardTokenizationDidEmitEvent(.willTokenizeCard)
         let task = Task { @MainActor in
-            let request = createCardTokenizationRequest(with: currentState)
             do {
-                let card = try await cardsService.tokenize(request: request)
+                let card = try await cardsService.tokenize(
+                    request: createCardTokenizationRequest(with: currentState)
+                )
                 logger.debug("Did tokenize card: \(String(describing: card))")
                 delegate?.cardTokenizationDidEmitEvent(.didTokenize(card: card))
                 try await delegate?.cardTokenization(didTokenizeCard: card, shouldSaveCard: currentState.shouldSaveCard)
@@ -338,8 +339,8 @@ final class DefaultCardTokenizationInteractor:
         if !resolvePreferredScheme {
             startedState.preferredScheme = nil
         } else if let issuerInformation, let delegate = delegate {
-            let rawScheme = delegate.preferredScheme(issuerInformation: issuerInformation)
-            startedState.preferredScheme = rawScheme.map(POCardScheme.init)
+            let scheme = delegate.cardTokenization(preferredSchemeWith: issuerInformation)
+            startedState.preferredScheme = scheme
         } else {
             startedState.preferredScheme = issuerInformation?.$scheme.typed
         }

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -357,6 +357,12 @@ final class DefaultCardTokenizationInteractor:
             evaluateEligibilityWith: .init(iin: iin, issuerInformation: issuerInformation)
         ).rawValue ?? .eligible(scheme: nil)
         let supportedEligibleSchemes = cardInformation.supportedEligibleSchemes ?? []
+        if case .eligible(let eligibleScheme?) = cardInformation.eligibility {
+            assert(
+                supportedEligibleSchemes.contains(eligibleScheme),
+                "Eligible scheme must be card's scheme or co-scheme."
+            )
+        }
         if supportedEligibleSchemes.count > 1,
            let preferredScheme = delegate?.cardTokenization(preferredSchemeWith: issuerInformation) {
             cardInformation.preferredScheme = preferredScheme

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -336,7 +336,7 @@ final class DefaultCardTokenizationInteractor:
         )
         cardInformation.eligibility = await delegate?.cardTokenization(
             evaluateEligibilityWith: .init(iin: iin, issuerInformation: issuerInformation)
-        ).eligibility ?? .eligible(schemes: nil)
+        ).rawValue ?? .eligible(scheme: nil)
         let supportedEligibleSchemes = cardInformation.supportedEligibleSchemes ?? []
         if case .eligible = cardInformation.eligibility, supportedEligibleSchemes.isEmpty {
             // Eligible without eligible schemes is treated as non eligible

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -332,12 +332,19 @@ final class DefaultCardTokenizationInteractor:
             return
         }
         var newState = currentState
-        newState.cardInformation = newCardInformation
-        if case .notEligible = newState.cardInformation.eligibility {
-            newState.number.issues.insert(.eligibility)
-        }
-        update(cvc: &newState.cvc, for: newState.cardInformation.preferredScheme)
+        update(state: &newState, with: newCardInformation)
         state = .started(newState)
+    }
+
+    private func update(
+        state: inout CardTokenizationInteractorState.Started,
+        with cardInformation: CardTokenizationInteractorState.CardInformation
+    ) {
+        state.cardInformation = cardInformation
+        if case .notEligible = cardInformation.eligibility {
+            state.number.issues.insert(.eligibility)
+        }
+        update(cvc: &state.cvc, for: cardInformation.preferredScheme)
     }
 
     private func createCardInformation(
@@ -507,11 +514,7 @@ final class DefaultCardTokenizationInteractor:
                     return
                 }
                 var newState = currentState.snapshot
-                newState.cardInformation = cardInformation
-                if case .notEligible = cardInformation.eligibility {
-                    newState.number.issues.insert(.eligibility)
-                }
-                update(cvc: &newState.cvc, for: cardInformation.preferredScheme)
+                update(state: &newState, with: cardInformation)
                 state = .started(newState)
                 if let schemes = cardInformation.supportedEligibleSchemes, schemes.count == 1 {
                     setTokenizingState()

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -322,7 +322,7 @@ final class DefaultCardTokenizationInteractor:
             let issuerInformation = try await cardsService.issuerInformation(
                 iin: currentState.cardInformation.partialIin
             )
-            newCardInformation = createCardInformation(
+            newCardInformation = await createCardInformation(
                 with: issuerInformation, iin: currentState.cardInformation.partialIin
             )
         } catch {
@@ -345,11 +345,11 @@ final class DefaultCardTokenizationInteractor:
 
     private func createCardInformation(
         with issuerInformation: POCardIssuerInformation, iin: String
-    ) -> CardTokenizationInteractorState.CardInformation {
+    ) async -> CardTokenizationInteractorState.CardInformation {
         var cardInformation = CardTokenizationInteractorState.CardInformation(
             partialIin: iin, issuerInformation: .completed(issuerInformation)
         )
-        cardInformation.eligibility = delegate?.cardTokenization(
+        cardInformation.eligibility = await delegate?.cardTokenization(
             evaluateEligibilityWith: .init(iin: iin, issuerInformation: issuerInformation)
         ).eligibility ?? .eligible(schemes: nil)
         let supportedEligibleSchemes = cardInformation.supportedEligibleSchemes ?? []

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -350,10 +350,6 @@ final class DefaultCardTokenizationInteractor:
             evaluateEligibilityWith: .init(iin: iin, issuerInformation: issuerInformation)
         ).rawValue ?? .eligible(scheme: nil)
         let supportedEligibleSchemes = cardInformation.supportedEligibleSchemes ?? []
-        if case .eligible = cardInformation.eligibility, supportedEligibleSchemes.isEmpty {
-            // Eligible without eligible schemes is treated as non eligible
-            cardInformation.eligibility = .notEligible(nil)
-        }
         if supportedEligibleSchemes.count > 1,
            let preferredScheme = delegate?.cardTokenization(preferredSchemeWith: issuerInformation) {
             cardInformation.preferredScheme = preferredScheme

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -246,7 +246,7 @@ final class DefaultCardTokenizationInteractor:
         default:
             errorMessage = .CardTokenization.Error.generic
         }
-        return String(resource: errorMessage)
+        return failure.errorDescription ?? String(resource: errorMessage)
     }
 
     // MARK: - Failure State

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Interactor/DefaultCardTokenizationInteractor.swift
@@ -154,7 +154,6 @@ final class DefaultCardTokenizationInteractor:
                 logger.debug("Did tokenize card: \(String(describing: card))")
                 delegate?.cardTokenizationDidEmitEvent(.didTokenize(card: card))
                 try await delegate?.cardTokenization(didTokenizeCard: card, shouldSaveCard: currentState.shouldSaveCard)
-                try await delegate?.processTokenizedCard(card: card)
                 setTokenizedState(card: card)
             } catch {
                 attemptRecoverTokenizationError(error)

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Symbols/StringResource+CardTokenization.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/Symbols/StringResource+CardTokenization.swift
@@ -72,6 +72,9 @@ extension POStringResource {
 
             /// Generic error description.
             static let generic = POStringResource("card-tokenization.error.generic", comment: "")
+
+            /// Generic eligibility error description.
+            static let eligibility = POStringResource("card-tokenization.error.eligibility", comment: "")
         }
 
         enum Button {

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/CardTokenizationViewModelState.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/CardTokenizationViewModelState.swift
@@ -10,9 +10,6 @@ import SwiftUI
 import ProcessOut
 @_spi(PO) import ProcessOutCoreUI
 
-// TODOs:
-// - Allow selecting card co-scheme when authorizing invoice or assigning token
-
 struct CardTokenizationViewModelState {
 
     struct Section: Identifiable {

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -46,7 +46,6 @@ final class DefaultCardTokenizationViewModel: ViewModel {
 
     private enum ItemId {
         static let error = "error"
-        static let eligibilityError = "eligibility-error"
         static let trackData = "track-data"
         static let scheme = "card-scheme"
         static let cardSave = "card-save"
@@ -90,16 +89,14 @@ final class DefaultCardTokenizationViewModel: ViewModel {
         startedState: InteractorState.Started, isSubmitting: Bool
     ) -> CardTokenizationViewModelState {
         var cardInformationItems = cardInformationInputItems(startedState: startedState)
-        if let error = startedState.recentErrorMessage {
-            let errorItem = State.ErrorItem(id: ItemId.error, description: error)
-            cardInformationItems.append(.error(errorItem))
-        }
         if case .notEligible(let failure) = startedState.cardInformation.eligibility {
             // todo(andrii-vysotskyi): use localized description
             let errorItem = State.ErrorItem(
-                id: ItemId.eligibilityError,
-                description: failure?.errorDescription ?? "Card is not supported."
+                id: ItemId.error, description: failure?.errorDescription ?? "Card is not supported."
             )
+            cardInformationItems.append(.error(errorItem))
+        } else if let error = startedState.recentErrorMessage {
+            let errorItem = State.ErrorItem(id: ItemId.error, description: error)
             cardInformationItems.append(.error(errorItem))
         }
         let sections = [
@@ -411,17 +408,12 @@ final class DefaultCardTokenizationViewModel: ViewModel {
     private func submitAction(
         startedState: InteractorState.Started, isSubmitting: Bool
     ) -> POButtonViewModel? {
-        let cardNotEligible = if case .notEligible = startedState.cardInformation.eligibility {
-            true
-        } else {
-            false
-        }
         let buttonConfiguration = configuration.submitButton
         let action = POButtonViewModel(
             id: "primary-button",
             title: buttonConfiguration.title ?? String(resource: .CardTokenization.Button.submit),
             icon: buttonConfiguration.icon,
-            isEnabled: startedState.areParametersValid && !cardNotEligible,
+            isEnabled: startedState.areParametersValid,
             isLoading: isSubmitting,
             role: .primary,
             action: { [weak self] in

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -78,8 +78,11 @@ final class DefaultCardTokenizationViewModel: ViewModel {
         case .tokenizing(let currentState):
             let newState = convertToState(startedState: currentState.snapshot, isSubmitting: true)
             self.state = newState
-        default:
-            break
+        case .evaluatingEligibility(let currentState):
+            let newState = convertToState(startedState: currentState.snapshot, isSubmitting: true)
+            self.state = newState
+        case .tokenized, .failure:
+            break // Ignored
         }
     }
 

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -90,9 +90,9 @@ final class DefaultCardTokenizationViewModel: ViewModel {
     ) -> CardTokenizationViewModelState {
         var cardInformationItems = cardInformationInputItems(startedState: startedState)
         if case .notEligible(let failure) = startedState.cardInformation.eligibility {
-            // todo(andrii-vysotskyi): use localized description
             let errorItem = State.ErrorItem(
-                id: ItemId.error, description: failure?.errorDescription ?? "Card is not supported."
+                id: ItemId.error,
+                description: failure?.errorDescription ?? String(resource: .CardTokenization.Error.eligibility)
             )
             cardInformationItems.append(.error(errorItem))
         } else if let error = startedState.recentErrorMessage {

--- a/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/CardTokenization/ViewModel/DefaultCardTokenizationViewModel.swift
@@ -165,10 +165,9 @@ final class DefaultCardTokenizationViewModel: ViewModel {
     }
 
     private func cardNumberIcon(startedState: InteractorState.Started) -> AnyView? {
-        // Scheme icon takes precedence over inject icon.
-        let scheme = startedState.issuerInformation?.coScheme != nil
-            ? startedState.preferredScheme
-            : startedState.issuerInformation?.$scheme.typed
+        let scheme = startedState.preferredScheme
+            ?? startedState.issuerInformation?.$scheme.typed
+            ?? startedState.preliminaryScheme
         if let image = scheme.flatMap(CardSchemeImageProvider.shared.image) {
             return AnyView(image)
         }

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
@@ -72,6 +72,7 @@ public protocol PODynamicCheckoutDelegate: AnyObject, Sendable {
     func dynamicCheckout(didEmitAlternativePaymentEvent event: PONativeAlternativePaymentEvent)
 
     /// Notifies delegate that alternative payment is about to start and allows to override default configuration.
+    @MainActor
     func dynamicCheckout(
         willStartAlternativePayment: PODynamicCheckoutPaymentMethod.NativeAlternativePayment
     ) -> PODynamicCheckoutAlternativePaymentConfiguration?
@@ -111,12 +112,16 @@ extension PODynamicCheckoutDelegate {
         nil
     }
 
+    // MARK: - Saved Payment Methods
+
     @MainActor
     public func dynamicCheckout(
         savedPaymentMethodsConfigurationWith invoiceRequest: POInvoiceRequest
     ) -> POSavedPaymentMethodsConfiguration {
         .init(invoiceRequest: invoiceRequest)
     }
+
+    // MARK: - Card Payment
 
     @MainActor
     public func dynamicCheckout(didEmitCardTokenizationEvent event: POCardTokenizationEvent) {
@@ -133,12 +138,7 @@ extension PODynamicCheckoutDelegate {
         nil
     }
 
-    @MainActor
-    public func dynamicCheckout(
-        willStartAlternativePayment: PODynamicCheckoutPaymentMethod.AlternativePayment
-    ) -> PODynamicCheckoutAlternativePaymentConfiguration? {
-        nil
-    }
+    // MARK: - Alternative Payment
 
     @MainActor
     public func dynamicCheckout(didEmitAlternativePaymentEvent event: PONativeAlternativePaymentEvent) {
@@ -147,10 +147,19 @@ extension PODynamicCheckoutDelegate {
 
     @MainActor
     public func dynamicCheckout(
+        willStartAlternativePayment: PODynamicCheckoutPaymentMethod.NativeAlternativePayment
+    ) -> PODynamicCheckoutAlternativePaymentConfiguration? {
+        nil
+    }
+
+    @MainActor
+    public func dynamicCheckout(
         alternativePaymentDefaultsWith request: PODynamicCheckoutAlternativePaymentDefaultsRequest
     ) async -> [String: String] {
         [:]
     }
+
+    // MARK: - Pass Kit
 
     @MainActor
     public func dynamicCheckout(willAuthorizeInvoiceWith request: PKPaymentRequest) async {

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Delegate/PODynamicCheckoutDelegate.swift
@@ -56,7 +56,7 @@ public protocol PODynamicCheckoutDelegate: AnyObject, Sendable {
     /// Allows to choose preferred scheme that will be selected by default based on issuer information. Default
     /// implementation returns primary scheme.
     @MainActor
-    func dynamicCheckout(preferredSchemeFor issuerInformation: POCardIssuerInformation) -> String?
+    func dynamicCheckout(preferredSchemeWith issuerInformation: POCardIssuerInformation) -> POCardScheme?
 
     /// Notifies the delegate before a card scanning session begins and allows
     /// providing a delegate to handle scanning events.
@@ -117,8 +117,8 @@ extension PODynamicCheckoutDelegate {
     }
 
     @MainActor
-    public func dynamicCheckout(preferredSchemeFor issuerInformation: POCardIssuerInformation) -> String? {
-        issuerInformation.scheme
+    public func dynamicCheckout(preferredSchemeWith issuerInformation: POCardIssuerInformation) -> POCardScheme? {
+        issuerInformation.$scheme.typed
     }
 
     @MainActor

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -566,7 +566,7 @@ final class DynamicCheckoutDefaultInteractor:
         case .started:
             currentState.isCancellable = currentState.snapshot.isCancellable
             self.state = .paymentProcessing(currentState)
-        case .tokenizing:
+        case .tokenizing, .evaluatingEligibility:
             currentState.isCancellable = false
             self.state = .paymentProcessing(currentState)
         case .tokenized:

--- a/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
+++ b/Sources/ProcessOutUI/Sources/Modules/DynamicCheckout/Interactor/DynamicCheckoutDefaultInteractor.swift
@@ -891,8 +891,8 @@ extension DynamicCheckoutDefaultInteractor: POCardTokenizationDelegate {
         )
     }
 
-    func preferredScheme(issuerInformation: POCardIssuerInformation) -> String? {
-        delegate?.dynamicCheckout(preferredSchemeFor: issuerInformation)
+    func cardTokenization(preferredSchemeWith issuerInformation: POCardIssuerInformation) -> POCardScheme? {
+        delegate?.dynamicCheckout(preferredSchemeWith: issuerInformation)
     }
 
     func shouldContinueTokenization(after failure: POFailure) -> Bool {


### PR DESCRIPTION
## Description
* Expose card's information issuer country code.
* Deprecate legacy preferred scheme resolution API.
* Support card eligibility evaluation during tokenization.
* Support custom error message describing card post processing failures.
* Allow creating `POFailure` with localized error description.

https://github.com/user-attachments/assets/3cca206c-8168-455e-a161-66bb69fd3e15

- 🛑 `4242 4242 4242 4242`: country error.
- 🛑 `5137 2100 0000 0158`: card type error. 
- ✅ `4010 0617 0000 0021`: filtered eligible schemes.

## Jira Issue
https://checkout.atlassian.net/browse/POM-475
